### PR TITLE
Support port numbers in server name

### DIFF
--- a/R/SWORD.R
+++ b/R/SWORD.R
@@ -17,8 +17,7 @@ parse_atom <- function(xml){
 # print.dataverse_sword_collection <- function(x, ...) {}
 # print.dataverse_sword_service_document <- function(x, ...) {}
 service_document <- function(key = Sys.getenv("DATAVERSE_KEY"), server = Sys.getenv("DATAVERSE_SERVER"), ...) {
-    server <- urltools::url_parse(server)$domain
-    u <- paste0("https://", server,"/dvn/api/data-deposit/v1.1/swordv2/service-document")
+    u <- paste0(api_url(server, prefix="dvn/api/"), "data-deposit/v1.1/swordv2/service-document")
     r <- httr::GET(u, httr::authenticate(key, ""), ...)
     httr::stop_for_status(r)
     x <- xml2::as_list(xml2::read_xml(httr::content(r, "text")))
@@ -79,14 +78,13 @@ service_document <- function(key = Sys.getenv("DATAVERSE_KEY"), server = Sys.get
 
 # note that there are two ways to create dataset: native API (`create_dataset`) and SWORD API (`initiate_dataset`)
 initiate_dataset <- function(dataverse, body, key = Sys.getenv("DATAVERSE_KEY"), server = Sys.getenv("DATAVERSE_SERVER"), ...) {
-    server <- urltools::url_parse(server)$domain
     if (inherits(dataverse, "sword_collection")) {
         u <- dataverse$url
     } else {
         if (inherits(dataverse, "dataverse")) {
             dataverse <- x$alias
         }
-        u <- paste0("https://", server,"/dvn/api/data-deposit/v1.1/swordv2/collection/dataverse/", dataverse)
+        u <- paste0(api_url(server, prefix="dvn/api/"), "data-deposit/v1.1/swordv2/collection/dataverse/", dataverse)
     }
     if (is.character(body) && file.exists(body)) {
         b <- httr::upload_file(body)
@@ -101,14 +99,13 @@ initiate_dataset <- function(dataverse, body, key = Sys.getenv("DATAVERSE_KEY"),
 }
 
 list_datasets <- function(dataverse, key = Sys.getenv("DATAVERSE_KEY"), server = Sys.getenv("DATAVERSE_SERVER"), ...) {
-    server <- urltools::url_parse(server)$domain
     if (inherits(dataverse, "sword_collection")) {
         u <- dataverse$url
     } else {
         if (inherits(dataverse, "dataverse")) {
             dataverse <- x$alias
         }
-        u <- paste0("https://", server,"/dvn/api/data-deposit/v1.1/swordv2/collection/dataverse/", dataverse)
+        u <- paste0(api_url(server, prefix="dvn/api/"), "data-deposit/v1.1/swordv2/collection/dataverse/", dataverse)
     }
     r <- httr::GET(u, httr::authenticate(key, ""), ...)
     httr::stop_for_status(r)
@@ -118,14 +115,13 @@ list_datasets <- function(dataverse, key = Sys.getenv("DATAVERSE_KEY"), server =
 }
 
 publish_dataverse <- function(dataverse, key = Sys.getenv("DATAVERSE_KEY"), server = Sys.getenv("DATAVERSE_SERVER"), ...) {
-    server <- urltools::url_parse(server)$domain
     if (inherits(dataverse, "sword_collection")) {
         u <- sub("/collection/", "/edit/", dataverse$url, fixed = TRUE)
     } else {
         if (inherits(dataverse, "dataverse")) {
             dataverse <- x$alias
         }
-        u <- paste0("https://", server,"/dvn/api/data-deposit/v1.1/swordv2/edit/dataverse/", dataverse)
+        u <- paste0(api_url(server, prefix="dvn/api/"), "data-deposit/v1.1/swordv2/edit/dataverse/", dataverse)
     }
     r <- httr::POST(u, httr::authenticate(key, ""), httr::add_headers("In-Progress" = "false"), ...)
     httr::stop_for_status(r)
@@ -166,9 +162,8 @@ create_zip.list <- function(x, ...) {
 }
 
 add_file <- function(dataset, file, key = Sys.getenv("DATAVERSE_KEY"), server = Sys.getenv("DATAVERSE_SERVER"), ...) {
-    server <- urltools::url_parse(server)$domain
     dataset <- prepend_doi(dataset)
-    u <- paste0("https://", server,"/dvn/api/data-deposit/v1.1/swordv2/edit-media/study/", dataset)
+    u <- paste0(api_url(server, prefix="dvn/api/"), "data-deposit/v1.1/swordv2/edit-media/study/", dataset)
     
     # file can be: a character vector of file names, a data.frame, or a list of R objects
     file <- create_zip(file)
@@ -182,27 +177,24 @@ add_file <- function(dataset, file, key = Sys.getenv("DATAVERSE_KEY"), server = 
 }
 
 delete_file <- function(dataset, id, key = Sys.getenv("DATAVERSE_KEY"), server = Sys.getenv("DATAVERSE_SERVER"), ...) {
-    server <- urltools::url_parse(server)$domain
     dataset <- prepend_doi(dataset)
-    u <- paste0("https://", server,"/dvn/api/data-deposit/v1.1/swordv2/edit-media/file/", id)
+    u <- paste0(api_url(server, prefix="dvn/api/"), "data-deposit/v1.1/swordv2/edit-media/file/", id)
     r <- httr::DELETE(u, httr::authenticate(key, ""), h, ...)
     httr::stop_for_status(r)
     httr::content(r, "text")
 }
 
 delete_dataset <- function(dataset, key = Sys.getenv("DATAVERSE_KEY"), server = Sys.getenv("DATAVERSE_SERVER"), ...) {
-    server <- urltools::url_parse(server)$domain
     dataset <- prepend_doi(dataset)
-    u <- paste0("https://", server,"/dvn/api/data-deposit/v1.1/swordv2/edit/study/", dataset)
+    u <- paste0(api_url(server, prefix="dvn/api/"), "data-deposit/v1.1/swordv2/edit/study/", dataset)
     r <- httr::DELETE(u, httr::authenticate(key, ""), ...)
     httr::stop_for_status(r)
     httr::content(r, "text")
 }
 
 publish_dataset <- function(dataset, key = Sys.getenv("DATAVERSE_KEY"), server = Sys.getenv("DATAVERSE_SERVER"), ...) {
-    server <- urltools::url_parse(server)$domain
     dataset <- prepend_doi(dataset)
-    u <- paste0("https://", server,"/dvn/api/data-deposit/v1.1/swordv2/edit/study/", dataset)
+    u <- paste0(api_url(server, prefix="dvn/api/"), "data-deposit/v1.1/swordv2/edit/study/", dataset)
     r <- httr::POST(u, httr::authenticate(key, ""), httr::add_headers("In-Progress" = "false"), ...)
     httr::stop_for_status(r)
     out <- xml2::as_list(xml2::read_xml(httr::content(r, "text")))
@@ -210,9 +202,8 @@ publish_dataset <- function(dataset, key = Sys.getenv("DATAVERSE_KEY"), server =
 }
 
 dataset_atom <- function(dataset, key = Sys.getenv("DATAVERSE_KEY"), server = Sys.getenv("DATAVERSE_SERVER"), ...) {
-    server <- urltools::url_parse(server)$domain
     dataset <- prepend_doi(dataset)
-    u <- paste0("https://", server,"/dvn/api/data-deposit/v1.1/swordv2/edit/study/", dataset)
+    u <- paste0(api_url(server, prefix="dvn/api/"), "data-deposit/v1.1/swordv2/edit/study/", dataset)
     r <- httr::GET(u, httr::authenticate(key, ""), ...)
     httr::stop_for_status(r)
     out <- parse_atom(httr::content(r, "text"))
@@ -220,9 +211,8 @@ dataset_atom <- function(dataset, key = Sys.getenv("DATAVERSE_KEY"), server = Sy
 }
 
 dataset_statement <- function(dataset, key = Sys.getenv("DATAVERSE_KEY"), server = Sys.getenv("DATAVERSE_SERVER"), ...) {
-    server <- urltools::url_parse(server)$domain
     dataset <- prepend_doi(dataset)
-    u <- paste0("https://", server,"/dvn/api/data-deposit/v1.1/swordv2/statement/study/", dataset)
+    u <- paste0(api_url(server, prefix="dvn/api/"), "data-deposit/v1.1/swordv2/statement/study/", dataset)
     r <- httr::GET(u, httr::authenticate(key, ""), ...)
     httr::stop_for_status(r)
     out <- xml2::as_list(xml2::read_xml(httr::content(r, "text")))

--- a/R/dataAccess.R
+++ b/R/dataAccess.R
@@ -21,7 +21,6 @@ function(file,
          server = Sys.getenv("DATAVERSE_SERVER"), 
          ...) {
     
-    server <- urltools::url_parse(server)$domain
     format <- match.arg(format)
     
     # from doi, get SWORD dataset statement, then get file ID
@@ -40,16 +39,16 @@ function(file,
     
     if (length(file) > 1) {
         file <- paste0(file, collapse = ",")
-        u <- paste0("https://", server, "/api/access/datafiles/", file)
+        u <- paste0(api_url(server), "access/datafiles/", file)
         r <- httr::GET(u, httr::add_headers("X-Dataverse-key" = key), ...)
         httr::stop_for_status(r)
         r
     } else {
         if (format == "bundle") {
-            u <- paste0("https://", server, "/api/access/datafile/bundle/", file)
+            u <- paste0(api_url(server), "access/datafile/bundle/", file)
             r <- httr::GET(u, httr::add_headers("X-Dataverse-key" = key), ...)
         } else {
-            u <- paste0("https://", server, "/api/access/datafile/", file)
+            u <- paste0(api_url(server), "access/datafile/", file)
             query <- list()
             if (!is.null(vars)) {
                 query$vars <- paste0(vars, collapse = ",")
@@ -79,7 +78,7 @@ function(file,
          server = Sys.getenv("DATAVERSE_SERVER"), 
          ...) {
     format <- match.arg(format)
-    u <- paste0("https://", server, "/api/access/datafile/", file, "/metadata/", format)
+    u <- paste0(api_url(server), "access/datafile/", file, "/metadata/", format)
     r <- httr::GET(u, httr::add_headers("X-Dataverse-key" = key), ...)
     httr::stop_for_status(r)
     r

--- a/R/native_dataset.R
+++ b/R/native_dataset.R
@@ -11,9 +11,8 @@
 #' \dontrun{}
 #' @export
 create_dataset <- function(dataverse, body, key = Sys.getenv("DATAVERSE_KEY"), server = Sys.getenv("DATAVERSE_SERVER"), ...) {
-    server <- urltools::url_parse(server)$domain
     dataverse <- dataverse_id(dataverse)
-    u <- paste0("https://", server,"/api/dataverses/", dataverse, "/datasets/")
+    u <- paste0(api_url(server), "dataverses/", dataverse, "/datasets/")
     r <- httr::POST(u, httr::add_headers("X-Dataverse-key" = key), body = body, encode = "json", ...)
     httr::stop_for_status(r)
     httr::content(r)
@@ -32,9 +31,8 @@ create_dataset <- function(dataverse, body, key = Sys.getenv("DATAVERSE_KEY"), s
 #' \dontrun{}
 #' @export
 update_dataset <- function(dataset, body, key = Sys.getenv("DATAVERSE_KEY"), server = Sys.getenv("DATAVERSE_SERVER"), ...) {
-    server <- urltools::url_parse(server)$domain
     dataset <- dataset_id(dataset)
-    u <- paste0("https://", server,"/api/datasets/", dataset, "/versions/:draft")
+    u <- paste0(api_url(server), "datasets/", dataset, "/versions/:draft")
     r <- httr::PUT(u, httr::add_headers("X-Dataverse-key" = key), body = body, encode = "json", ...)
     httr::stop_for_status(r)
     httr::content(r)
@@ -55,9 +53,8 @@ update_dataset <- function(dataset, body, key = Sys.getenv("DATAVERSE_KEY"), ser
 #' \dontrun{}
 #' @export
 publish_dataset <- function(dataset, minor = TRUE, key = Sys.getenv("DATAVERSE_KEY"), server = Sys.getenv("DATAVERSE_SERVER"), ...) {
-    server <- urltools::url_parse(server)$domain
     dataset <- dataset_id(dataset)
-    u <- paste0("https://", server,"/api/datasets/", dataset, "/actions/:publish?type=", if (minor) "minor" else "major")
+    u <- paste0(api_url(server), "datasets/", dataset, "/actions/:publish?type=", if (minor) "minor" else "major")
     r <- httr::POST(u, httr::add_headers("X-Dataverse-key" = key), ...)
     httr::stop_for_status(r)
     httr::content(r)
@@ -76,12 +73,11 @@ publish_dataset <- function(dataset, minor = TRUE, key = Sys.getenv("DATAVERSE_K
 #' \dontrun{}
 #' @export
 get_dataset <- function(dataset, version = ":latest", key = Sys.getenv("DATAVERSE_KEY"), server = Sys.getenv("DATAVERSE_SERVER"), ...) {
-    server <- urltools::url_parse(server)$domain
     dataset <- dataset_id(dataset)
     if (!is.null(version)) {
-        u <- paste0("https://", server,"/api/datasets/", dataset, "/versions/", version)
+        u <- paste0(api_url(server), "datasets/", dataset, "/versions/", version)
     } else {
-        u <- paste0("https://", server,"/api/datasets/", dataset)
+        u <- paste0(api_url(server), "datasets/", dataset)
     }
     r <- httr::GET(u, httr::add_headers("X-Dataverse-key" = key), ...)
     httr::stop_for_status(r)
@@ -108,9 +104,8 @@ get_dataset <- function(dataset, version = ":latest", key = Sys.getenv("DATAVERS
 #' @export
 delete_dataset <- function(dataset, key = Sys.getenv("DATAVERSE_KEY"), server = Sys.getenv("DATAVERSE_SERVER"), ...) {
     # can only delete a "draft" dataset
-    server <- urltools::url_parse(server)$domain
     dataset <- dataset_id(dataset)
-    u <- paste0("https://", server,"/api/datasets/", dataset, "/versions/:draft")
+    u <- paste0(api_url(server), "datasets/", dataset, "/versions/:draft")
     r <- httr::DELETE(u, httr::add_headers("X-Dataverse-key" = key), ...)
     httr::stop_for_status(r)
     httr::content(r)
@@ -128,9 +123,8 @@ delete_dataset <- function(dataset, key = Sys.getenv("DATAVERSE_KEY"), server = 
 #' \dontrun{}
 #' @export
 dataset_versions <- function(dataset, key = Sys.getenv("DATAVERSE_KEY"), server = Sys.getenv("DATAVERSE_SERVER"), ...) {
-    server <- urltools::url_parse(server)$domain
     dataset <- dataset_id(dataset)
-    u <- paste0("https://", server,"/api/datasets/", dataset, "/versions")
+    u <- paste0(api_url(server), "datasets/", dataset, "/versions")
     r <- httr::GET(u, httr::add_headers("X-Dataverse-key" = key), ...)
     httr::stop_for_status(r)
     out <- httr::content(r)$data
@@ -154,9 +148,8 @@ dataset_versions <- function(dataset, key = Sys.getenv("DATAVERSE_KEY"), server 
 #' \dontrun{}
 #' @export
 dataset_files <- function(dataset, version = ":latest", key = Sys.getenv("DATAVERSE_KEY"), server = Sys.getenv("DATAVERSE_SERVER"), ...) {
-    server <- urltools::url_parse(server)$domain
     dataset <- dataset_id(dataset)
-    u <- paste0("https://", server,"/api/datasets/", dataset, "/versions/", version, "/files")
+    u <- paste0(api_url(server), "datasets/", dataset, "/versions/", version, "/files")
     r <- httr::GET(u, httr::add_headers("X-Dataverse-key" = key), ...)
     httr::stop_for_status(r)
     out <- jsonlite::fromJSON(httr::content(r, "text"), simplifyDataFrame = FALSE)$data
@@ -177,12 +170,11 @@ dataset_files <- function(dataset, version = ":latest", key = Sys.getenv("DATAVE
 #' \dontrun{}
 #' @export
 dataset_metadata <- function(dataset, version = ":latest", block = "citation", key = Sys.getenv("DATAVERSE_KEY"), server = Sys.getenv("DATAVERSE_SERVER"), ...) {
-    server <- urltools::url_parse(server)$domain
     dataset <- dataset_id(dataset)
     if (!is.null(block)) {
-        u <- paste0("https://", server,"/api/datasets/", dataset, "/versions/", version, "/metadata/", block)
+        u <- paste0(api_url(server), "datasets/", dataset, "/versions/", version, "/metadata/", block)
     } else {
-        u <- paste0("https://", server,"/api/datasets/", dataset, "/versions/", version, "/metadata")
+        u <- paste0(api_url(server), "datasets/", dataset, "/versions/", version, "/metadata")
     }
     
     r <- httr::GET(u, httr::add_headers("X-Dataverse-key" = key), ...)

--- a/R/native_dv.R
+++ b/R/native_dv.R
@@ -10,9 +10,8 @@
 #' \dontrun{}
 #' @export
 get_dataverse <- function(dataverse, key = Sys.getenv("DATAVERSE_KEY"), server = Sys.getenv("DATAVERSE_SERVER"), ...) {
-    server <- urltools::url_parse(server)$domain
     dataverse <- dataverse_id(dataverse)
-    u <- paste0("https://", server,"/api/dataverses/", dataverse)
+    u <- paste0(api_url(server), "dataverses/", dataverse)
     r <- httr::GET(u, httr::add_headers("X-Dataverse-key" = key), ...)
     httr::stop_for_status(r)
     out <- jsonlite::fromJSON(httr::content(r, "text"))
@@ -34,8 +33,7 @@ get_dataverse <- function(dataverse, key = Sys.getenv("DATAVERSE_KEY"), server =
 #' \dontrun{}
 #' @export
 create_dataverse <- function(dataverse, key = Sys.getenv("DATAVERSE_KEY"), server = Sys.getenv("DATAVERSE_SERVER"), ...) {
-    server <- urltools::url_parse(server)$domain
-    u <- paste0("https://", server,"/api/dataverses/", dataverse)
+    u <- paste0(api_url(server), "dataverses/", dataverse)
     r <- httr::POST(u, httr::add_headers("X-Dataverse-key" = key), ...)
     httr::stop_for_status(r)
     httr::content(r)
@@ -53,9 +51,8 @@ create_dataverse <- function(dataverse, key = Sys.getenv("DATAVERSE_KEY"), serve
 #' \dontrun{}
 #' @export
 delete_dataverse <- function(dataverse, key = Sys.getenv("DATAVERSE_KEY"), server = Sys.getenv("DATAVERSE_SERVER"), ...) {
-    server <- urltools::url_parse(server)$domain
     dataverse <- dataverse_id(dataverse)
-    u <- paste0("https://", server,"/api/dataverses/", dataverse)
+    u <- paste0(api_url(server), "dataverses/", dataverse)
     r <- httr::DELETE(u, httr::add_headers("X-Dataverse-key" = key), ...)
     httr::stop_for_status(r)
     httr::content(r)
@@ -73,9 +70,8 @@ delete_dataverse <- function(dataverse, key = Sys.getenv("DATAVERSE_KEY"), serve
 #' \dontrun{}
 #' @export
 dataverse_contents <- function(dataverse, key = Sys.getenv("DATAVERSE_KEY"), server = Sys.getenv("DATAVERSE_SERVER"), ...) {
-    server <- urltools::url_parse(server)$domain
     dataverse <- dataverse_id(dataverse)
-    u <- paste0("https://", server,"/api/dataverses/", dataverse, "/contents")
+    u <- paste0(api_url(server), "dataverses/", dataverse, "/contents")
     r <- httr::GET(u, httr::add_headers("X-Dataverse-key" = key), ...)
     httr::stop_for_status(r)
     out <- jsonlite::fromJSON(httr::content(r, "text"), simplifyDataFrame = FALSE)
@@ -95,9 +91,8 @@ dataverse_contents <- function(dataverse, key = Sys.getenv("DATAVERSE_KEY"), ser
 #' \dontrun{}
 #' @export
 get_facets <- function(dataverse, key = Sys.getenv("DATAVERSE_KEY"), server = Sys.getenv("DATAVERSE_SERVER"), ...) {
-    server <- urltools::url_parse(server)$domain
     dataverse <- dataverse_id(dataverse)
-    u <- paste0("https://", server,"/api/dataverses/", dataverse, "/facets")
+    u <- paste0(api_url(server), "dataverses/", dataverse, "/facets")
     r <- httr::GET(u, httr::add_headers("X-Dataverse-key" = key), ...)
     httr::stop_for_status(r)
     httr::content(r)$data
@@ -115,9 +110,8 @@ get_facets <- function(dataverse, key = Sys.getenv("DATAVERSE_KEY"), server = Sy
 #' \dontrun{}
 #' @export
 dataverse_metadata <- function(dataverse, key = Sys.getenv("DATAVERSE_KEY"), server = Sys.getenv("DATAVERSE_SERVER"), ...) {
-    server <- urltools::url_parse(server)$domain
     dataverse <- dataverse_id(dataverse)
-    u <- paste0("https://", server,"/api/dataverses/", dataverse, "/metadatablocks")
+    u <- paste0(api_url(server), "dataverses/", dataverse, "/metadatablocks")
     r <- httr::GET(u, httr::add_headers("X-Dataverse-key" = key), ...)
     httr::stop_for_status(r)
     httr::content(r)$data
@@ -137,9 +131,8 @@ dataverse_metadata <- function(dataverse, key = Sys.getenv("DATAVERSE_KEY"), ser
 #' \dontrun{}
 #' @export
 set_dataverse_metadata <- function(dataverse, body, root = TRUE, key = Sys.getenv("DATAVERSE_KEY"), server = Sys.getenv("DATAVERSE_SERVER"), ...) {
-    server <- urltools::url_parse(server)$domain
     dataverse <- dataverse_id(dataverse)
-    u <- paste0("https://", server,"/api/dataverses/", dataverse, "/metadatablocks/", tolower(as.character(root)))
+    u <- paste0(api_url(server), "dataverses/", dataverse, "/metadatablocks/", tolower(as.character(root)))
     r <- httr::POST(u, httr::add_headers("X-Dataverse-key" = key), ...)
     httr::stop_for_status(r)
     httr::content(r)$data
@@ -157,9 +150,8 @@ set_dataverse_metadata <- function(dataverse, body, root = TRUE, key = Sys.geten
 #' \dontrun{}
 #' @export
 publish_dataverse <- function(dataverse, key = Sys.getenv("DATAVERSE_KEY"), server = Sys.getenv("DATAVERSE_SERVER"), ...) {
-    server <- urltools::url_parse(server)$domain
     dataverse <- dataverse_id(dataverse)
-    u <- paste0("https://", server,"/api/dataverses/", dataverse, "/actions/:publish")
+    u <- paste0(api_url(server), "dataverses/", dataverse, "/actions/:publish")
     r <- httr::POST(u, httr::add_headers("X-Dataverse-key" = key), ...)
     httr::stop_for_status(r)
     httr::content(r)$data

--- a/R/native_roles.R
+++ b/R/native_roles.R
@@ -10,8 +10,7 @@
 #' \dontrun{}
 #' @export
 get_role <- function(role, key = Sys.getenv("DATAVERSE_KEY"), server = Sys.getenv("DATAVERSE_SERVER"), ...) {
-    server <- urltools::url_parse(server)$domain
-    u <- paste0("https://", server,"/api/roles/", role)
+    u <- paste0(api_url(server), "roles/", role)
     r <- httr::POST(u, httr::add_headers("X-Dataverse-key" = key), ...)
     httr::stop_for_status(r)
     j <- jsonlite::fromJSON(httr::content(r, "text"))$data
@@ -30,8 +29,7 @@ get_role <- function(role, key = Sys.getenv("DATAVERSE_KEY"), server = Sys.geten
 #' \dontrun{}
 #' @export
 delete_role <- function(role, key = Sys.getenv("DATAVERSE_KEY"), server = Sys.getenv("DATAVERSE_SERVER"), ...) {
-    server <- urltools::url_parse(server)$domain
-    u <- paste0("https://", server,"/api/roles/", role)
+    u <- paste0(api_url(server), "roles/", role)
     r <- httr::DELETE(u, httr::add_headers("X-Dataverse-key" = key), ...)
     httr::stop_for_status(r)
     j <- jsonlite::fromJSON(httr::content(r, "text"))$data
@@ -55,9 +53,8 @@ create_group <- function(dataverse, alias, name, description, key = Sys.getenv("
     b <- list(description = description,
               displayName = name,
               aliasToOwner = alias)
-    server <- urltools::url_parse(server)$domain
     dataverse <- dataverse_id(dataverse)
-    u <- paste0("https://", server, "/api/dataverses/", dataverse, "/groups")
+    u <- paste0(api_url(server), "dataverses/", dataverse, "/groups")
     r <- httr::POST(u, httr::add_headers("X-Dataverse-key" = key), body = b, encode = "json", ...)
     httr::stop_for_status(r)
     j <- jsonlite::fromJSON(httr::content(r, "text"))$data
@@ -81,9 +78,8 @@ update_group <- function(dataverse, alias, name, description, key = Sys.getenv("
     b <- list(description = description,
               displayName = name,
               alias = alias)
-    server <- urltools::url_parse(server)$domain
     dataverse <- dataverse_id(dataverse)
-    u <- paste0("https://", server, "/api/dataverses/", dataverse, "/groups/", alias)
+    u <- paste0(api_url(server), "dataverses/", dataverse, "/groups/", alias)
     r <- httr::PUT(u, httr::add_headers("X-Dataverse-key" = key), body = b, encode = "json", ...)
     httr::stop_for_status(r)
     j <- jsonlite::fromJSON(httr::content(r, "text"))$data
@@ -101,9 +97,8 @@ update_group <- function(dataverse, alias, name, description, key = Sys.getenv("
 #' \dontrun{}
 #' @export
 list_groups <- function(dataverse, key = Sys.getenv("DATAVERSE_KEY"), server = Sys.getenv("DATAVERSE_SERVER"), ...) {
-    server <- urltools::url_parse(server)$domain
     dataverse <- dataverse_id(dataverse)
-    u <- paste0("https://", server, "/api/dataverses/", dataverse, "/groups")
+    u <- paste0(api_url(server), "dataverses/", dataverse, "/groups")
     r <- httr::GET(u, httr::add_headers("X-Dataverse-key" = key), ...)
     httr::stop_for_status(r)
     j <- jsonlite::fromJSON(httr::content(r, "text"))$data
@@ -122,9 +117,8 @@ list_groups <- function(dataverse, key = Sys.getenv("DATAVERSE_KEY"), server = S
 #' \dontrun{}
 #' @export
 get_group <- function(dataverse, alias, key = Sys.getenv("DATAVERSE_KEY"), server = Sys.getenv("DATAVERSE_SERVER"), ...) {
-    server <- urltools::url_parse(server)$domain
     dataverse <- dataverse_id(dataverse)
-    u <- paste0("https://", server, "/api/dataverses/", dataverse, "/groups/", alias)
+    u <- paste0(api_url(server), "dataverses/", dataverse, "/groups/", alias)
     r <- httr::GET(u, httr::add_headers("X-Dataverse-key" = key), ...)
     httr::stop_for_status(r)
     j <- jsonlite::fromJSON(httr::content(r, "text"))$data
@@ -143,9 +137,8 @@ get_group <- function(dataverse, alias, key = Sys.getenv("DATAVERSE_KEY"), serve
 #' \dontrun{}
 #' @export
 delete_group <- function(dataverse, alias, key = Sys.getenv("DATAVERSE_KEY"), server = Sys.getenv("DATAVERSE_SERVER"), ...) {
-    server <- urltools::url_parse(server)$domain
     dataverse <- dataverse_id(dataverse)
-    u <- paste0("https://", server, "/api/dataverses/", dataverse, "/groups/", alias)
+    u <- paste0(api_url(server), "dataverses/", dataverse, "/groups/", alias)
     r <- httr::DELETE(u, httr::add_headers("X-Dataverse-key" = key), ...)
     httr::stop_for_status(r)
     httr::content(r, "text")
@@ -170,9 +163,8 @@ add_roles_to_group <- function(dataverse, alias, role, key = Sys.getenv("DATAVER
     if(is.null(server) || server == "") {
         stop("'server' is missing, but required")
     }
-    server <- urltools::url_parse(server)$domain
     dataverse <- dataverse_id(dataverse)
-    u <- paste0("https://", server, "/api/dataverses/", dataverse, "/groups/", alias, "/roleAssignees/", role)
+    u <- paste0(api_url(server), "dataverses/", dataverse, "/groups/", alias, "/roleAssignees/", role)
     r <- httr::PUT(u, httr::add_headers("X-Dataverse-key" = key), ...)
     httr::stop_for_status(r)
     j <- jsonlite::fromJSON(httr::content(r, "text"))$data
@@ -192,9 +184,8 @@ add_roles_to_group <- function(dataverse, alias, role, key = Sys.getenv("DATAVER
 #' \dontrun{}
 #' @export
 remove_role_from_group <- function(dataverse, alias, role, key = Sys.getenv("DATAVERSE_KEY"), server = Sys.getenv("DATAVERSE_SERVER"), ...) {
-    server <- urltools::url_parse(server)$domain
     dataverse <- dataverse_id(dataverse)
-    u <- paste0("https://", server, "/api/dataverses/", dataverse, "/groups/", alias, "/roleAssignees/", role)
+    u <- paste0(api_url(server), "dataverses/", dataverse, "/groups/", alias, "/roleAssignees/", role)
     r <- httr::DELETE(u, httr::add_headers("X-Dataverse-key" = key), ...)
     httr::stop_for_status(r)
     httr::content(r, "text")
@@ -212,16 +203,15 @@ remove_role_from_group <- function(dataverse, alias, role, key = Sys.getenv("DAT
 #' \dontrun{}
 #' @export
 get_roles <- function(dataverse, key = Sys.getenv("DATAVERSE_KEY"), server = Sys.getenv("DATAVERSE_SERVER"), ...) {
-    server <- urltools::url_parse(server)$domain
     if (!missing(dataverse)) {
         dataverse <- dataverse_id(dataverse)
-        u <- paste0("https://", server,"/api/dataverses/", dataverse, "/roles")
+        u <- paste0(api_url(server), "dataverses/", dataverse, "/roles")
         r <- httr::GET(u, httr::add_headers("X-Dataverse-key" = key), ...)
         httr::stop_for_status(r)
         out <- jsonlite::fromJSON(httr::content(r, "text"))$data
         structure(lapply(out, `class<-`, "dataverse_role"))
     } else {
-        u <- paste0("https://", server,"/api/admin/roles")
+        u <- paste0(api_url(server), "admin/roles")
         r <- httr::GET(u, httr::add_headers("X-Dataverse-key" = key), ...)
         httr::stop_for_status(r)
     }
@@ -240,10 +230,9 @@ get_roles <- function(dataverse, key = Sys.getenv("DATAVERSE_KEY"), server = Sys
 #' @export
 create_role <- function(dataverse, alias, name, description, permissions, 
                          key = Sys.getenv("DATAVERSE_KEY"), server = Sys.getenv("DATAVERSE_SERVER"), ...) {
-    server <- urltools::url_parse(server)$domain
     b <- list(alias = alias, name = name, description = description, permissions = permissions)
     dataverse <- dataverse_id(dataverse)
-    u <- paste0("https://", server,"/api/dataverses/", dataverse, "/roles")
+    u <- paste0(api_url(server), "dataverses/", dataverse, "/roles")
     r <- httr::POST(u, httr::add_headers("X-Dataverse-key" = key), body = b, encode = "json", ...)
     httr::stop_for_status(r)
     j <- jsonlite::fromJSON(httr::content(r, "text"))$data
@@ -261,9 +250,8 @@ create_role <- function(dataverse, alias, name, description, permissions,
 #' \dontrun{}
 #' @export
 get_assignments <- function(dataverse, key = Sys.getenv("DATAVERSE_KEY"), server = Sys.getenv("DATAVERSE_SERVER"), ...) {
-    server <- urltools::url_parse(server)$domain
     dataverse <- dataverse_id(dataverse)
-    u <- paste0("https://", server,"/api/dataverses/", dataverse, "/assignments")
+    u <- paste0(api_url(server), "dataverses/", dataverse, "/assignments")
     r <- httr::GET(u, httr::add_headers("X-Dataverse-key" = key), ...)
     httr::stop_for_status(r)
     out <- jsonlite::fromJSON(httr::content(r, "text"))$data
@@ -283,9 +271,8 @@ get_assignments <- function(dataverse, key = Sys.getenv("DATAVERSE_KEY"), server
 #' \dontrun{}
 #' @export
 assign_role <- function(dataverse, assignee, role, key = Sys.getenv("DATAVERSE_KEY"), server = Sys.getenv("DATAVERSE_SERVER"), ...) {
-    server <- urltools::url_parse(server)$domain
     dataverse <- dataverse_id(dataverse)
-    u <- paste0("https://", server,"/api/dataverses/", dataverse, "/assignments")
+    u <- paste0(api_url(server), "dataverses/", dataverse, "/assignments")
     b <- list(assignee = assignee, role = role)
     r <- httr::POST(u, httr::add_headers("X-Dataverse-key" = key), body = b, encode = "json", ...)
     httr::stop_for_status(r)
@@ -305,9 +292,8 @@ assign_role <- function(dataverse, assignee, role, key = Sys.getenv("DATAVERSE_K
 #' \dontrun{}
 #' @export
 delete_assignment <- function(dataverse, assignment, key = Sys.getenv("DATAVERSE_KEY"), server = Sys.getenv("DATAVERSE_SERVER"), ...) {
-    server <- urltools::url_parse(server)$domain
     dataverse <- dataverse_id(dataverse)
-    u <- paste0("https://", server,"/api/dataverses/", dataverse, "/assignments/", assignment)
+    u <- paste0(api_url(server), "dataverses/", dataverse, "/assignments/", assignment)
     r <- httr::DELETE(u, httr::add_headers("X-Dataverse-key" = key), ...)
     httr::stop_for_status(r)
     httr::content(r)

--- a/R/native_user.R
+++ b/R/native_user.R
@@ -12,8 +12,7 @@
 #' }
 #' @export
 create_user <- function(password, key = Sys.getenv("DATAVERSE_KEY"), server = Sys.getenv("DATAVERSE_SERVER"), ...) {
-    server <- urltools::url_parse(server)$domain
-    u <- paste0("https://", server,"/api/builtin-users?password=", password)
+    u <- paste0(api_url(server), "builtin-users?password=", password)
     r <- httr::POST(u, httr::add_headers("X-Dataverse-key" = key), ...)
     httr::stop_for_status(r)
     httr::content(r)
@@ -34,8 +33,7 @@ create_user <- function(password, key = Sys.getenv("DATAVERSE_KEY"), server = Sy
 #' }
 #' @export
 get_user_key <- function(user, password, server = Sys.getenv("DATAVERSE_SERVER"), ...) {
-    server <- urltools::url_parse(server)$domain
-    u <- paste0("https://", server,"/api/builtin-users/", user, "/api-token?password=", password)
+    u <- paste0(api_url(server), "builtin-users/", user, "/api-token?password=", password)
     r <- httr::GET(u, ...)
     httr::stop_for_status(r)
     j <- jsonlite::fromJSON(httr::content(r, "text"))

--- a/R/search.R
+++ b/R/search.R
@@ -60,9 +60,8 @@ function(...,
     stopifnot(per_page >0 && per_page <= 1000)
     sort <- match.arg(sort)
     order <- match.arg(order)
-    server <- urltools::url_parse(server)$domain
     
-    u <- paste0("https://", server, "/api/search")
+    u <- paste0(api_url(server), "search")
     r <- httr::GET(u, httr::add_headers("X-Dataverse-key" = key), query = query)
     httr::stop_for_status(r)
     out <- jsonlite::fromJSON(httr::content(r, "text"))

--- a/R/utils.R
+++ b/R/utils.R
@@ -93,3 +93,15 @@ print.dataverse_file <- function(x, ...) {
     invisible(x)
 }
 
+# other functions
+
+api_url <- function(server, prefix="api/") {
+    server <- urltools::url_parse(server)
+    if(server$port == "") {
+        domain <- server$domain
+    } else {
+        domain <- paste0(server$domain, ":", server$port)
+    }
+    url <- paste0("https://", domain, "/", prefix)
+    return(url)
+}


### PR DESCRIPTION
I have factored out the generation of the server address into a separate function, and added support for alternative port numbers. This was something that we needed when running the client against a test dataverse server.