### PR TITLE
replace 'ghit' package with 'remotes'

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -10,3 +10,5 @@ man-roxygen/*
 \.Rmd2$
 .github/
 .github/*
+^doc$
+^Meta$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -12,3 +12,4 @@ man-roxygen/*
 .github/*
 ^doc$
 ^Meta$
+^codecov\.yml$

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 README.html
+doc
+Meta

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ matrix:
       r_check_args: '--ignore-vignettes --no-examples'
 
 r_packages:
+- htmltools
+- digest
 - covr
 - rmarkdown
 - knitr

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,16 @@
+# Travis's native R Image (http://docs.travis-ci.com/user/languages/r/)
 language: r
 sudo: false
 cache: packages
+warnings_are_errors: true
+
 matrix:
   include:
     - os: linux
-      dist: precise
-      sudo: false
-      r_build_args: '--no-build-vignettes'
-      r_check_args: '--ignore-vignettes --no-examples'
-    - os: linux
-      dist: trusty
-      sudo: required
+      dist: xenial
       env: R_CODECOV=true
+    - os: linux
+      dist: bionic
     - os: osx
       osx_image: xcode8.2
       before_install:
@@ -20,23 +19,10 @@ matrix:
       latex: false
       r_build_args: '--no-build-vignettes'
       r_check_args: '--ignore-vignettes --no-examples'
-    - os: osx
-      osx_image: xcode7.3
-      latex: false
-      r_build_args: '--no-build-vignettes'
-      r_check_args: '--ignore-vignettes --no-examples'
 
-r_packages:
-- htmltools
-- digest
-- covr
-- rmarkdown
-- knitr
+r_github_packages:
+  - r-lib/covr
 
 after_success:
-  - Rscript -e 'covr::coveralls()'
-
-notifications:
-  email:
-    on_success: change
-    on_failure: change
+  - if [[ "${R_CODECOV}" ]]; then Rscript -e 'covr::codecov()'; fi
+  # - Rscript -e 'covr::coveralls()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,12 +27,12 @@ matrix:
       r_check_args: '--ignore-vignettes --no-examples'
 
 r_packages:
-- covr
-- rmarkdown
-- knitr
+- r-lib/covr
+- rstudio/rmarkdown
+- yihui/knitr
 
 after_success:
-  - if [[ "${R_CODECOV}" ]]; then R -e 'covr::codecov()'; fi
+  - Rscript -e 'covr::coveralls()'
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,9 @@ matrix:
       r_check_args: '--ignore-vignettes --no-examples'
 
 r_packages:
-- r-lib/covr
-- rstudio/rmarkdown
-- yihui/knitr
+- covr
+- rmarkdown
+- knitr
 
 after_success:
   - Rscript -e 'covr::coveralls()'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,4 +25,4 @@ License: GPL-2
 URL: https://github.com/iqss/dataverse-client-r
 BugReports: https://github.com/iqss/dataverse-client-r/issues
 VignetteBuilder: knitr
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,8 @@ Suggests:
     knitr,
     testthat,
     UNF,
-    foreign
+    foreign,
+    covr
 Description: Provides access to Dataverse version 4 APIs <https://dataverse.org/>, 
     enabling data search, retrieval, and deposit. For Dataverse versions <= 4.0, 
     use the deprecated 'dvn' package <https://cran.r-project.org/package=dvn>.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,4 +25,5 @@ License: GPL-2
 URL: https://github.com/iqss/dataverse-client-r
 BugReports: https://github.com/iqss/dataverse-client-r/issues
 VignetteBuilder: knitr
+Encoding: UTF-8
 RoxygenNote: 6.1.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@
 * Tests now run with an explicit empty API key.
 * Fixed a bug in internal function `parse_dataset()`, related to capitalization. (#17)
 * Vignette uses 'remotes' package in place of the archived 'ghit' package. (#24 @wibeasley)
-* Modernize Travis yaml file (specify repo's org; newer covr script; #24).
+* Updated config for Travis-CI, such as switch to xenial Ubuntu release, specify repo's org, and specify covr parameters. (#25 @wibeasley)
 
 # CHANGES TO dataverse 0.1.24
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * Pass `key`, `server`, and `...` arguments to internal `get_dataverse()` and `get_dataset()` calls.
 * Tests now run with an explicit empty API key.
 * Fixed a bug in internal function `parse_dataset()`, related to capitalization. (#17)
+* Vignette uses 'remotes' package in place of the archived 'ghit' package (#24 @wibeasley)
 
 # CHANGES TO dataverse 0.1.24
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,8 @@
 * Pass `key`, `server`, and `...` arguments to internal `get_dataverse()` and `get_dataset()` calls.
 * Tests now run with an explicit empty API key.
 * Fixed a bug in internal function `parse_dataset()`, related to capitalization. (#17)
-* Vignette uses 'remotes' package in place of the archived 'ghit' package (#24 @wibeasley)
+* Vignette uses 'remotes' package in place of the archived 'ghit' package. (#24 @wibeasley)
+* Modernize Travis yaml file (specify repo's org; newer covr script; #24).
 
 # CHANGES TO dataverse 0.1.24
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+comment: false
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%

--- a/man/files.Rd
+++ b/man/files.Rd
@@ -9,8 +9,8 @@ get_file(file, dataset = NULL, format = c("original", "RData", "prep",
   "bundle"), vars = NULL, key = Sys.getenv("DATAVERSE_KEY"),
   server = Sys.getenv("DATAVERSE_SERVER"), ...)
 
-get_file_metadata(file, dataset = NULL, format = c("ddi", "preprocessed"),
-  key = Sys.getenv("DATAVERSE_KEY"),
+get_file_metadata(file, dataset = NULL, format = c("ddi",
+  "preprocessed"), key = Sys.getenv("DATAVERSE_KEY"),
   server = Sys.getenv("DATAVERSE_SERVER"), ...)
 }
 \arguments{

--- a/man/get_dataset.Rd
+++ b/man/get_dataset.Rd
@@ -6,7 +6,8 @@
 \alias{dataset_files}
 \title{Get dataset}
 \usage{
-get_dataset(dataset, version = ":latest", key = Sys.getenv("DATAVERSE_KEY"),
+get_dataset(dataset, version = ":latest",
+  key = Sys.getenv("DATAVERSE_KEY"),
   server = Sys.getenv("DATAVERSE_SERVER"), ...)
 
 dataset_metadata(dataset, version = ":latest", block = "citation",

--- a/man/get_user_key.Rd
+++ b/man/get_user_key.Rd
@@ -4,7 +4,8 @@
 \alias{get_user_key}
 \title{Get API Key}
 \usage{
-get_user_key(user, password, server = Sys.getenv("DATAVERSE_SERVER"), ...)
+get_user_key(user, password, server = Sys.getenv("DATAVERSE_SERVER"),
+  ...)
 }
 \arguments{
 \item{user}{A character vector specifying a Dataverse server username.}

--- a/man/initiate_sword_dataset.Rd
+++ b/man/initiate_sword_dataset.Rd
@@ -4,7 +4,8 @@
 \alias{initiate_sword_dataset}
 \title{Initiate dataset (SWORD)}
 \usage{
-initiate_sword_dataset(dataverse, body, key = Sys.getenv("DATAVERSE_KEY"),
+initiate_sword_dataset(dataverse, body,
+  key = Sys.getenv("DATAVERSE_KEY"),
   server = Sys.getenv("DATAVERSE_SERVER"), ...)
 }
 \arguments{

--- a/man/publish_dataset.Rd
+++ b/man/publish_dataset.Rd
@@ -4,7 +4,8 @@
 \alias{publish_dataset}
 \title{Publish dataset}
 \usage{
-publish_dataset(dataset, minor = TRUE, key = Sys.getenv("DATAVERSE_KEY"),
+publish_dataset(dataset, minor = TRUE,
+  key = Sys.getenv("DATAVERSE_KEY"),
   server = Sys.getenv("DATAVERSE_SERVER"), ...)
 }
 \arguments{

--- a/vignettes/A-introduction.Rmd
+++ b/vignettes/A-introduction.Rmd
@@ -28,10 +28,10 @@ They can be accessed from [CRAN](https://cran.r-project.org/package=dataverse) o
 The dataverse client package can be installed from [CRAN](https://cran.r-project.org/package=dataverse), and you can find the latest development version and report any issues on GitHub:
 
 ```R
-if (!require("ghit")) {
-    install.packages("ghit")
+if (!require("remotes")) {
+    install.packages("remotes")
 }
-ghit::install_github("iqss/dataverse-client-r")
+remotes::install_github("iqss/dataverse-client-r")
 library("dataverse")
 ```
 

--- a/vignettes/A-introduction.Rmd2
+++ b/vignettes/A-introduction.Rmd2
@@ -28,10 +28,10 @@ They can be accessed from [CRAN](https://cran.r-project.org/package=dataverse) o
 The dataverse client package can be installed from [CRAN](https://cran.r-project.org/package=dataverse), and you can find the latest development version and report any issues on GitHub:
 
 ```R
-if (!require("ghit")) {
-    install.packages("ghit")
+if (!require("remotes")) {
+    install.packages("remotes")
 }
-ghit::install_github("iqss/dataverse-client-r")
+remotes::install_github("iqss/dataverse-client-r")
 library("dataverse")
 ```
 


### PR DESCRIPTION
The package was removed/archived on CRAN May 2018.
https://cran.r-project.org/package=ghit

>Package ‘ghit’ was removed from the CRAN repository.
>
>Formerly available versions can be obtained from the archive.
>
>Archived on 2018-05-10 at the request of the maintainer Thomas J. Leeper <thosjleeper@gmail.com>.


The [repo](https://github.com/cloudyr/ghit) says
>This package is now deprecated.
>
>No further updates will be made here or sent to CRAN.
>
>Please use remotes instead.
