### PR TITLE
Fix handling of fq

### DIFF
--- a/R/dataverse_search.R
+++ b/R/dataverse_search.R
@@ -93,9 +93,10 @@ function(...,
     query[["show_relevance"]] <- show_relevance
     ## show_facets
     query[["show_facets"]] <- show_facets
-    ## fq
-    if (!is.null(start)) {
-        query[["fq"]] <- match.arg(fq)
+    ## fq 
+    # we're passing the unencoded fq string on to the API using I() as the API doesn't handle encoded strings properly
+    if (!is.null(fq)) {
+      query[["fq"]] <- I(fq)
     }
     
     # setup URL

--- a/tests/testthat/tests-search.R
+++ b/tests/testthat/tests-search.R
@@ -16,6 +16,14 @@ test_that("date range search using fq", {
     expect_true(is.data.frame(dataverse_search("*", fq = "dateSort:[2018-01-01T00:00:00Z+TO+2019-01-01T00:00:00Z]", type = "dataset", key = "", server = "dataverse.harvard.edu")))
 })
 
+test_that("publication year using fq", {
+    expect_true(is.data.frame(dataverse_search("*", fq = "publicationDate:2018", type = "dataset", key = "", server = "dataverse.harvard.edu")))
+})
+
+test_that("filter dataverses by subject using fq", {
+    expect_true(is.data.frame(dataverse_search("*", fq = "subject_ss:Social+Sciences", type = "dataverse", key = "", server = "dataverse.harvard.edu")))
+})
+
 test_that("empty fq search", {
-  expect_length(dataverse_search("*", fq = "dateSort:[2019-02-01T00:00:00Z+TO+2019-01-01T00:00:00Z]", type = "dataset", key = "", server = "dataverse.harvard.edu"), 0)
+    expect_length(dataverse_search("*", fq = "dateSort:[2019-02-01T00:00:00Z+TO+2019-01-01T00:00:00Z]", type = "dataset", key = "", server = "dataverse.harvard.edu"), 0)
 })

--- a/tests/testthat/tests-search.R
+++ b/tests/testthat/tests-search.R
@@ -11,3 +11,7 @@ test_that("named argument search", {
 test_that("simple search w/type argument", {
     expect_true(is.data.frame(dataverse_search(author = "Gary King", type = "dataset", key = "", server = "dataverse.harvard.edu")))
 })
+
+test_that("date range search using fq", {
+    expect_true(is.data.frame(dataverse_search(author = "*", fq = "dateSort:[2018-01-01T00:00:00Z+TO+2019-01-01T00:00:00Z]", type = "dataset", key = "", server = "dataverse.harvard.edu")))
+})

--- a/tests/testthat/tests-search.R
+++ b/tests/testthat/tests-search.R
@@ -13,5 +13,9 @@ test_that("simple search w/type argument", {
 })
 
 test_that("date range search using fq", {
-    expect_true(is.data.frame(dataverse_search(author = "*", fq = "dateSort:[2018-01-01T00:00:00Z+TO+2019-01-01T00:00:00Z]", type = "dataset", key = "", server = "dataverse.harvard.edu")))
+    expect_true(is.data.frame(dataverse_search("*", fq = "dateSort:[2018-01-01T00:00:00Z+TO+2019-01-01T00:00:00Z]", type = "dataset", key = "", server = "dataverse.harvard.edu")))
+})
+
+test_that("empty fq search", {
+  expect_length(dataverse_search("*", fq = "dateSort:[2019-02-01T00:00:00Z+TO+2019-01-01T00:00:00Z]", type = "dataset", key = "", server = "dataverse.harvard.edu"), 0)
 })


### PR DESCRIPTION
Currently fq is completely broken:
1. It requires start to be set for no reason
2. It fails because match.arg will always fail since no args are given in the function

This fix does three things:
1. Test for fq rather than start
2. get rid of the match.arg -- since fq is super flexible, we can't use that here
3. enclose the fq query in I to prevent URL encoding (see https://github.com/r-lib/httr/issues/540#issuecomment-426012904 ). Otherwise, httr encodes colons, square brackets and + and e.g. the [example for date range search](http://guides.dataverse.org/en/latest/api/search.html#date-range-search-example) breaks

Please ensure the following before submitting a PR:

 - [x] if suggesting code changes or improvements, [open an issue](https://github.com/leeper/dataverse/issues/new) first
 - [ ] for all but trivial changes (e.g., typo fixes), add your name to [DESCRIPTION](https://github.com/leeper/dataverse/blob/master/DESCRIPTION)
 - [ ] for all but trivial changes (e.g., typo fixes), documentation your change in [NEWS.md](https://github.com/leeper/dataverse/blob/master/NEWS.md) with a parenthetical reference to the issue number being addressed
 - [x] if changing documentation, edit files in `/R` not `/man` and run `devtools::document()` to update documentation
 - [x] add code or new test files to [`/tests`](https://github.com/leeper/dataverse/tree/master/tests/testthat) for any new functionality or bug fix
 - [ ] make sure `R CMD check` runs without error before submitting the PR

