### PR TITLE
Add ability to download zip of multiple files

### DIFF
--- a/R/get_file.R
+++ b/R/get_file.R
@@ -6,7 +6,6 @@
 #' @template ds
 #' @param format A character string specifying a file format. For \code{get_file}: by default, this is \dQuote{original} (the original file format). If \dQuote{RData} or \dQuote{prep} is used, an alternative is returned. If \dQuote{bundle}, a compressed directory containing a bundle of file formats is returned. For \code{get_file_metadata}, this is \dQuote{ddi}.
 #' @param vars A character vector specifying one or more variable names, used to extract a subset of the data.
-#' @param unzip A Boolean operator. If TRUE, multiple files downloaded get unzipped. If false the .zip file is downloaded.
 #' @template envvars
 #' @template dots
 #' @return \code{get_file_metadata} returns a character vector containing a DDI metadata file. \code{get_file} returns a raw vector (or list of raw vectors, if \code{length(file) > 1}).
@@ -31,9 +30,9 @@
 #' flist <- dataset_files(2692151)
 #' get_file(flist[[2]])
 #'
-#' # retrieve all files in a dataset in their original format (will return a .zip file)
+#' # retrieve all files in a dataset in their original format (returns a list of raw vectors)
 #' file_ids <- get_dataset("doi:10.7910/DVN/CXOB4K")[['files']]$id
-#' f3 <- get_file(file_ids, format = "original", unzip = FALSE)
+#' f3 <- get_file(file_ids, format = "original")
 #' # read file as data.frame
 #' if (require("rio")) {
 #'   tmp <- tempfile(fileext = ".dta")
@@ -53,7 +52,6 @@ get_file <-
            dataset = NULL,
            format = c("original", "RData", "prep", "bundle"),
            # thumb = TRUE,
-           unzip = TRUE,
            vars = NULL,
            key = Sys.getenv("DATAVERSE_KEY"),
            server = Sys.getenv("DATAVERSE_SERVER"),
@@ -73,39 +71,35 @@ get_file <-
       fileid <- file
     }
 
-    # request multiple files -----
-    if (length(fileid) > 1) {
-        fileid <- paste0(fileid, collapse = ",")
-        u <- paste0(api_url(server), "access/datafiles/", fileid)
-        r <- httr::GET(u, httr::add_headers("X-Dataverse-key" = key), ...)
-        httr::stop_for_status(r)
-        if (unzip) {
-          tempf <- tempfile(fileext = ".zip")
-          tempd <- tempfile()
-          dir.create(tempd)
-          on.exit(unlink(tempf), add = TRUE)
-          on.exit(unlink(tempd), add = TRUE)
-          writeBin(httr::content(r, as = "raw"), tempf)
-          to_extract <- utils::unzip(tempf, list = TRUE)
-          out <- lapply(to_extract$Name[to_extract$Name != "MANIFEST.TXT"], function(zipf) {
-            utils::unzip(zipfile = tempf, files = zipf, exdir = tempd)
-            readBin(file.path(tempd, zipf), "raw", n = 1e8)
-          })
-          return(out)
-        }
-        else {
-          return(httr::content(r, as = "raw"))
-        }
-    }
+    # # request multiple files -----
+    # if (length(fileid) > 1) {
+    #     fileid <- paste0(fileid, collapse = ",")
+    #     u <- paste0(api_url(server), "access/datafiles/", fileid)
+    #     r <- httr::GET(u, httr::add_headers("X-Dataverse-key" = key), ...)
+    #     httr::stop_for_status(r)
+    #     tempf <- tempfile(fileext = ".zip")
+    #     tempd <- tempfile()
+    #     dir.create(tempd)
+    #     on.exit(unlink(tempf), add = TRUE)
+    #     on.exit(unlink(tempd), add = TRUE)
+    #     writeBin(httr::content(r, as = "raw"), tempf)
+    #     to_extract <- utils::unzip(tempf, list = TRUE)
+    #     out <- lapply(to_extract$Name[to_extract$Name != "MANIFEST.TXT"], function(zipf) {
+    #       utils::unzip(zipfile = tempf, files = zipf, exdir = tempd)
+    #       readBin(file.path(tempd, zipf), "raw", n = 1e8)
+    #     })
+    #     return(out)
+    # }
 
-    # request single file -----
-    if (length(fileid) == 1) {
+    # downloading files sequentially and add the raw vectors to a list
+    out <- vector("list", length(fileid))
+    for (i in 1:length(fileid)) {
         if (format == "bundle") {
-            u <- paste0(api_url(server), "access/datafile/bundle/", fileid)
+            u <- paste0(api_url(server), "access/datafile/bundle/", fileid[i])
             r <- httr::GET(u, httr::add_headers("X-Dataverse-key" = key), ...)
         }
         if (format != "bundle") {
-            u <- paste0(api_url(server), "access/datafile/", fileid)
+            u <- paste0(api_url(server), "access/datafile/", fileid[i])
             query <- list()
             if (!is.null(vars)) {
                 query$vars <- paste0(vars, collapse = ",")
@@ -116,7 +110,7 @@ get_file <-
 
             # request single file in non-bundle format ----
             # add query if ingesting a tab (detect from original file name)
-            if (length(query) == 1 & grepl("\\.tab$", file)) {
+            if (length(query) == 1 & grepl("\\.tab$", file[i])) {
                 r <- httr::GET(u, httr::add_headers("X-Dataverse-key" = key), query = query, ...)
             } else {
                 # do not add query if not an ingestion file
@@ -124,7 +118,15 @@ get_file <-
             }
         }
         httr::stop_for_status(r)
-        return(httr::content(r, as = "raw"))
+        out[[i]] <-  httr::content(r, as = "raw")
+    }
+    # return the raw vector if there's a single file
+    if (length(out) == 1) {
+      return (out[[1]])
+    }
+    else {
+      # return a list of raw vectors otherwise
+      return (out)
     }
   }
 

--- a/man/files.Rd
+++ b/man/files.Rd
@@ -9,7 +9,6 @@ get_file(
   file,
   dataset = NULL,
   format = c("original", "RData", "prep", "bundle"),
-  unzip = TRUE,
   vars = NULL,
   key = Sys.getenv("DATAVERSE_KEY"),
   server = Sys.getenv("DATAVERSE_SERVER"),
@@ -31,8 +30,6 @@ get_file_metadata(
 \item{dataset}{An integer specifying a dataset identification number or an object of class \dQuote{dataverse_dataset}. The identification number is the dataset's persistent identification number (not the integer specifying a specific version of the dataset, such as returned by \code{\link{dataset_versions}}).}
 
 \item{format}{A character string specifying a file format. For \code{get_file}: by default, this is \dQuote{original} (the original file format). If \dQuote{RData} or \dQuote{prep} is used, an alternative is returned. If \dQuote{bundle}, a compressed directory containing a bundle of file formats is returned. For \code{get_file_metadata}, this is \dQuote{ddi}.}
-
-\item{unzip}{A Boolean operator. If TRUE, multiple files downloaded get unzipped. If false the .zip file is downloaded.}
 
 \item{vars}{A character vector specifying one or more variable names, used to extract a subset of the data.}
 
@@ -72,7 +69,7 @@ f2 <- get_file(2692202)
 flist <- dataset_files(2692151)
 get_file(flist[[2]])
 
-# retrieve all files in a dataset in their original format (will return a .zip file)
+# retrieve all files in a dataset in their original format (returns a list of raw vectors)
 file_ids <- get_dataset("doi:10.7910/DVN/CXOB4K")[['files']]$id
 f3 <- get_file(file_ids, format = "original")
 # read file as data.frame

--- a/man/files.Rd
+++ b/man/files.Rd
@@ -9,6 +9,7 @@ get_file(
   file,
   dataset = NULL,
   format = c("original", "RData", "prep", "bundle"),
+  unzip = TRUE,
   vars = NULL,
   key = Sys.getenv("DATAVERSE_KEY"),
   server = Sys.getenv("DATAVERSE_SERVER"),
@@ -25,11 +26,13 @@ get_file_metadata(
 )
 }
 \arguments{
-\item{file}{An integer specifying a file identifier; or, if \code{doi} is specified, a character string specifying a file name within the DOI-identified dataset; or an object of class \dQuote{dataverse_file} as returned by \code{\link{dataset_files}}.}
+\item{file}{An integer specifying a file identifier; or a vector of integers specifying file identifiers; or, if \code{doi} is specified, a character string specifying a file name within the DOI-identified dataset; or an object of class \dQuote{dataverse_file} as returned by \code{\link{dataset_files}}.}
 
 \item{dataset}{An integer specifying a dataset identification number or an object of class \dQuote{dataverse_dataset}. The identification number is the dataset's persistent identification number (not the integer specifying a specific version of the dataset, such as returned by \code{\link{dataset_versions}}).}
 
 \item{format}{A character string specifying a file format. For \code{get_file}: by default, this is \dQuote{original} (the original file format). If \dQuote{RData} or \dQuote{prep} is used, an alternative is returned. If \dQuote{bundle}, a compressed directory containing a bundle of file formats is returned. For \code{get_file_metadata}, this is \dQuote{ddi}.}
+
+\item{unzip}{A Boolean operator. If TRUE, multiple files downloaded get unzipped. If false the .zip file is downloaded.}
 
 \item{vars}{A character vector specifying one or more variable names, used to extract a subset of the data.}
 
@@ -69,6 +72,9 @@ f2 <- get_file(2692202)
 flist <- dataset_files(2692151)
 get_file(flist[[2]])
 
+# retrieve all files in a dataset in their original format (will return a .zip file)
+file_ids <- get_dataset("doi:10.7910/DVN/CXOB4K")[['files']]$id
+f3 <- get_file(file_ids, format = "original")
 # read file as data.frame
 if (require("rio")) {
   tmp <- tempfile(fileext = ".dta")

--- a/tests/testthat/tests-get_file.R
+++ b/tests/testthat/tests-get_file.R
@@ -19,3 +19,10 @@ test_that("download file from file id", {
   expect_true(is.raw(actual))
   expect_true(1000 < object.size(actual)) # Should be 1+ KB
 })
+
+test_that("download of zip of multiple files with file id", {
+  file_ids <- get_dataset("doi:10.70122/FK2/FAN622")[['files']]$id
+  actual <- get_file(file_ids, format="original")
+  expect_true(is.raw(actual))
+  expect_true(1000 < object.size(actual)) # Should be 1+ KB
+})

--- a/tests/testthat/tests-get_file.R
+++ b/tests/testthat/tests-get_file.R
@@ -22,10 +22,13 @@ test_that("download file from file id", {
 
 test_that("download multiple files with file id - no folder", {
   file_ids <- get_dataset("doi:10.70122/FK2/LZAJEQ", server = "demo.dataverse.org")[['files']]$id
-  actual <- get_file(file_ids, format="original", server = "demo.dataverse.org")
+  actual <- get_file(
+    file_ids,
+    format="original",
+    server = "demo.dataverse.org")
   expect_true(length(actual) == 2) # two files in the dataset
   expect_true(is.raw(actual[[2]]))
-  expect_true(300 < object.size(actual[[2]])) # Should be >300 B
+  expect_true(object.size(actual[[2]]) > 300) # Should be >300 B
 })
 
 test_that("download multiple files with file id - with folders", {
@@ -33,5 +36,5 @@ test_that("download multiple files with file id - with folders", {
   actual <- get_file(file_ids, format="original", server = "demo.dataverse.org")
   expect_true(length(actual) == 2) # two files in the dataset
   expect_true(is.raw(actual[[2]]))
-  expect_true(300 < object.size(actual[[2]])) # Should be >300 B
+  expect_true(object.size(actual[[2]]) > 70) # Should be >70 B
 })

--- a/tests/testthat/tests-get_file.R
+++ b/tests/testthat/tests-get_file.R
@@ -20,9 +20,18 @@ test_that("download file from file id", {
   expect_true(1000 < object.size(actual)) # Should be 1+ KB
 })
 
-test_that("download of zip of multiple files with file id", {
-  file_ids <- get_dataset("doi:10.70122/FK2/FAN622")[['files']]$id
-  actual <- get_file(file_ids, format="original")
-  expect_true(is.raw(actual))
-  expect_true(1000 < object.size(actual)) # Should be 1+ KB
+test_that("download multiple files with file id - no folder", {
+  file_ids <- get_dataset("doi:10.70122/FK2/LZAJEQ", server = "demo.dataverse.org")[['files']]$id
+  actual <- get_file(file_ids, format="original", server = "demo.dataverse.org")
+  expect_true(length(actual) == 2) # two files in the dataset
+  expect_true(is.raw(actual[[2]]))
+  expect_true(300 < object.size(actual[[2]])) # Should be >300 B
+})
+
+test_that("download multiple files with file id - with folders", {
+  file_ids <- get_dataset("doi:10.70122/FK2/V54HGA", server = "demo.dataverse.org")[['files']]$id
+  actual <- get_file(file_ids, format="original", server = "demo.dataverse.org")
+  expect_true(length(actual) == 2) # two files in the dataset
+  expect_true(is.raw(actual[[2]]))
+  expect_true(300 < object.size(actual[[2]])) # Should be >300 B
 })


### PR DESCRIPTION
Please ensure the following before submitting a PR:

 - [ ] if suggesting code changes or improvements, [open an issue](https://github.com/IQSS/dataverse-client-r/issues/new) first
 - [ ] for all but trivial changes (e.g., typo fixes), add your name to [DESCRIPTION](https://github.com/IQSS/dataverse-client-r/blob/master/DESCRIPTION)
 - [ ] for all but trivial changes (e.g., typo fixes), documentation your change in [NEWS.md](https://github.com/IQSS/dataverse-client-r/blob/master/NEWS.md) with a parenthetical reference to the issue number being addressed
 - [x] if changing documentation, edit files in `/R` not `/man` and run `devtools::document()` to update documentation
 - [x] add code or new test files to [`/tests`](https://github.com/IQSS/dataverse-client-r/tree/master/tests/testthat) for any new functionality or bug fix
 - [x] make sure `R CMD check` runs without error before submitting the PR


This PR does three things:
1. Fixes a regression from https://github.com/IQSS/dataverse-client-r/commit/5ec375b21d5f9c5bb884f611d5aeb89c702da37b that broke the ability to specify a vector of fileids to download
2. Documents and test said functionality
3. ~Adds an additional parameter `unzip` to `get_file()` to give users the option to download individual files (the current behavior) or a single .zip file (my preferred behavior).~ (see below)

I'll add more tests if you're OK with the general approach here, but wanted to check first. I'd also need access to the dataverse on demo to properly test (all tests using the demo DV currently fail as I assume you know)