### PR TITLE
Respond to CRAN failures

### DIFF
--- a/tests/testthat/tests-dataverse_contents.R
+++ b/tests/testthat/tests-dataverse_contents.R
@@ -29,5 +29,5 @@ test_that("dataverse for 'dataverse-client-r'", {
   dv      <- get_dataverse(dataverse = "dataverse-client-r")
   actual    <- dataverse_contents(dv)
   ds_index  <- which(sapply(actual, function(x) x$identifier) == "FK2/HXJVJU")
-  expect_equal(actual[[1]], expected)
+  expect_equal(actual[[ds_index]], expected)
 })

--- a/tests/testthat/tests-list_datasets.R
+++ b/tests/testthat/tests-list_datasets.R
@@ -57,7 +57,10 @@ test_that("dataverse for 'dataverse-client-r'", {
     )
 
   dv <- get_dataverse("dataverse-client-r")
-  actual <- list_datasets(dv)
+  dvlist <- list_datasets(dv)
+  ds_order  <- c(which(dvlist$datasets$id == "https://demo.dataverse.org/dvn/api/data-deposit/v1.1/swordv2/edit/study/doi:10.70122/FK2/HXJVJU"),
+                 which(dvlist$datasets$id == "https://demo.dataverse.org/dvn/api/data-deposit/v1.1/swordv2/edit/study/doi:10.70122/FK2/PPIAXE"))
+  actual <- dvlist[ds_order, ]
 
   expect_equal(actual, expected)
 })

--- a/tests/testthat/tests-list_datasets.R
+++ b/tests/testthat/tests-list_datasets.R
@@ -57,10 +57,10 @@ test_that("dataverse for 'dataverse-client-r'", {
     )
 
   dv <- get_dataverse("dataverse-client-r")
-  dvlist <- list_datasets(dv)
-  ds_order  <- c(which(dvlist$datasets$id == "https://demo.dataverse.org/dvn/api/data-deposit/v1.1/swordv2/edit/study/doi:10.70122/FK2/HXJVJU"),
-                 which(dvlist$datasets$id == "https://demo.dataverse.org/dvn/api/data-deposit/v1.1/swordv2/edit/study/doi:10.70122/FK2/PPIAXE"))
-  actual <- dvlist[ds_order, ]
+  actual <- list_datasets(dv)
+  ds_order  <- c(which(actual$datasets$id == "https://demo.dataverse.org/dvn/api/data-deposit/v1.1/swordv2/edit/study/doi:10.70122/FK2/HXJVJU"),
+                 which(actual$datasets$id == "https://demo.dataverse.org/dvn/api/data-deposit/v1.1/swordv2/edit/study/doi:10.70122/FK2/PPIAXE"))
+  actual$datasets <- actual$datasets[ds_order, ]
 
   expect_equal(actual, expected)
 })


### PR DESCRIPTION
Fixing the order for two tests failed on their debian. 

Related to the reordering.

── Failure (tests-dataverse_contents.R:32:3): dataverse for 'dataverse-client-r' ──
── Failure (tests-list_datasets.R:62:3): dataverse for 'dataverse-client-r' ────