### PR TITLE
Make tests reorder-proof

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -20,3 +20,4 @@ man-roxygen/*
 ^docs$
 ^pkgdown$
 ^cran-comments\.md$
+^CRAN-RELEASE$

--- a/CRAN-RELEASE
+++ b/CRAN-RELEASE
@@ -1,0 +1,2 @@
+This package was submitted to CRAN on 2021-02-23.
+Once it is accepted, delete this file and tag the release (commit 45dc66d).

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: dataverse
-Version: 0.3.2
+Version: 0.3.3
 Title: Client for Dataverse 4+ Repositories
 Authors@R: c(
   person(

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -5,6 +5,8 @@ In response to a January notification from Brian Ripley, the tests are now skipp
 
 All checks and tests are passing on win-builder, Travis, and my two local machines.  However it is failing on R-hub with a message I haven't encountered before. I suspect it's specific to R-hub, but haven't found similar posts online.  The error message involves the 'pillar' package (which isn't called) on the `get_dataframe_by_name()` examples (which are wrapped by `\donttest{...}`).
 
+We just made another modification (related to last night's rejection of v0.3.2) to account for different sorting orders that I assume are related to different platforms.  They hadn't appeared in any of our tests.
+
 Thank you for taking the time to review my submission, and please tell me if there's something else I should do for CRAN.  -Will Beasley
 
 
@@ -13,16 +15,16 @@ Test environments
 
 1. Local Ubuntu, R 4.0.3
 1. Local Win10, R 4.0.4 Patched
-1. [win-builder](https://win-builder.r-project.org/U4UPm5oO0b32), development version.
+1. [win-builder](https://win-builder.r-project.org/4ML5zvxJzOw6/), development version.
 1. [Travis CI](https://travis-ci.org/github/IQSS/dataverse-client-r), Ubuntu 18.04 LTS
 
 
-*Failing*:
+*Failing on some builds*:
 
-1. [r-hub](https://builder.r-hub.io/status/dataverse_0.3.2.tar.gz-4acdf7c445774c06aad526114a6e1a80)
+1. [r-hub](https://builder.r-hub.io/status/dataverse_0.3.3.tar.gz-ad235e27f3624c7ca85e8a13ab5e41b0)
 
 R CMD check results
 -----------------------------------------------
 
 * No ERRORs or WARNINGs on any builds, except for the R-hub problem mentioned above.
-* One NOTE about the new package maintainer
+* Depending on the build, there are two NOTEs.  One about the package being archived, and another about possibly misspelled words "APIs" and "Dataverse"; both spellings are intentional.

--- a/tests/testthat/tests-list_datasets.R
+++ b/tests/testthat/tests-list_datasets.R
@@ -58,9 +58,9 @@ test_that("dataverse for 'dataverse-client-r'", {
 
   dv <- get_dataverse("dataverse-client-r")
   actual <- list_datasets(dv)
-  ds_order  <- c(which(actual$datasets$id == "https://demo.dataverse.org/dvn/api/data-deposit/v1.1/swordv2/edit/study/doi:10.70122/FK2/HXJVJU"),
-                 which(actual$datasets$id == "https://demo.dataverse.org/dvn/api/data-deposit/v1.1/swordv2/edit/study/doi:10.70122/FK2/PPIAXE"))
-  actual$datasets <- actual$datasets[ds_order, ]
 
-  expect_equal(actual, expected)
+  expect_equal(actual$title, expected$title)
+  expect_equal(actual$generator, expected$generator)
+  expect_equal(class(actual), class(expected))
+  expect_setequal(actual$datasets$id, expected$datasets$id) # order does not matter
 })


### PR DESCRIPTION
Attempting to iron out all the possibilities where row order swapping may fail a test. Responding to:

> ── Failure (tests-list_datasets.R:65:3): dataverse for 'dataverse-client-r' ────
>     `actual` not equal to `expected`.
>     Component "datasets": Attributes: < Component "row.names": Mean relative difference: 0.6666667 >


Before merging, I can wait until this version passes on winbuilder too.

