### PR TITLE
One remaining skip_test

### DIFF
--- a/tests/testthat/tests-get_file.R
+++ b/tests/testthat/tests-get_file.R
@@ -50,6 +50,7 @@ test_that("download multiple files with file id - with folders", {
 
 # Informative error message (PR #30)
 test_that("More informative error message when file does not exist", {
+  testthat::skip_on_cran()
   # wrong server
   expect_error(get_file(2972336, server = "demo.dataverse.org"),
                regexp = "API endpoint does not exist on this server")


### PR DESCRIPTION
`testthat::skip*` is needed even for tests that are meant to fail; otherwise the test errors out when the resource is not online.