### PR TITLE
Documentation and progress bar (for v0.3.10)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,7 +43,6 @@ Imports:
     xml2
 Suggests:
     covr,
-    foreign,
     haven,
     knitr,
     purrr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: dataverse
-Version: 0.3.9.9000
+Version: 0.3.10
 Title: Client for Dataverse 4+ Repositories
 Authors@R:
    c(person(given = "Shiro", 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: dataverse
-Version: 0.3.9
+Version: 0.3.9.9000
 Title: Client for Dataverse 4+ Repositories
 Authors@R:
    c(person(given = "Shiro", 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,6 +58,6 @@ URL: https://iqss.github.io/dataverse-client-r/, https://dataverse.org/, https:/
 BugReports: https://github.com/iqss/dataverse-client-r/issues
 VignetteBuilder: knitr
 Encoding: UTF-8
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Roxygen: list(markdown = TRUE)
 Config/testthat/edition: 3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # dataverse (development version)
 
+# CHANGES in dataverse 0.3.10
+
+* Add progress bar for all downloads (#108)
+* Minor documentation improvements (#64, #107)
+* No longer relies on `foreign` (#34)
+
 # CHANGES in dataverse 0.3.9
 
 * Change maintainer to @kuriwaki

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# dataverse (development version)
+
 # CHANGES in dataverse 0.3.9
 
 * Change maintainer to @kuriwaki

--- a/R/get_dataframe.R
+++ b/R/get_dataframe.R
@@ -1,22 +1,27 @@
 #' Download dataverse file as a dataframe
 #'
-#' Use `get_dataframe_by_name` if you know the name of the datafile and the DOI
+#'
+#' @details Reads in the Dataverse file into the R environment with any
+#'  user-specified function, such as `read.csv` or `readr` functions.
+#'
+#'  Use `get_dataframe_by_name` if you know the name of the datafile and the DOI
 #'  of the dataset. Use `get_dataframe_by_doi` if you know the DOI of the datafile
 #'  itself. Use `get_dataframe_by_id` if you know the numeric ID of the
-#'  datafile.
+#'  datafile. For files that are not datasets, the more generic `get_file` that
+#'  downloads the content as a binary is simpler.
 #'
 #' @rdname get_dataframe
 #'
 #' @param filename The name of the file of interest, with file extension, for example
 #' `"roster-bulls-1996.tab"`.
-#' @param .f The function to used for reading in the raw dataset. This user
-#' must choose the appropriate function: for example if the target is a .rds
-#' file, then `.f` should be `readRDS` or `readr::read_rds`.
-#' @param original A logical, defaulting to TRUE. Whether to read the ingested,
+#' @param .f The function to used for reading in the raw dataset. The user
+#'  must choose the appropriate function: for example if the target is a .rds
+#'  file, then `.f` should be `readRDS` or `readr::read_rds`. It can be a custom
+#'  function defined by the user. See examples for details.
+#'
+#' @param original A logical, defaulting to `TRUE`. Whether to read the ingested,
 #' archival version of the datafile if one exists. The archival versions are tab-delimited
 #' `.tab` files so if `original = FALSE`, `.f` is set to `readr::read_tsv`.
-#' If functions to read the original version is available, then `original = TRUE`
-#' with a specified `.f` is better.
 #'
 #' @inheritDotParams get_file
 #'
@@ -26,7 +31,9 @@
 #'
 #' @examples
 #' \dontrun{
-#' # Retrieve data.frame from dataverse DOI and file name
+#' # 1. For files originally in plain-text (.csv, .tsv), we recommend
+#' # retreiving data.frame from dataverse DOI and file name, or the file's DOI.
+#'
 #' df_tab <-
 #'   get_dataframe_by_name(
 #'     filename = "roster-bulls-1996.tab",
@@ -34,25 +41,17 @@
 #'     server   = "demo.dataverse.org"
 #'   )
 #'
-#' # Retrieve the same file from file DOI
 #' df_tab <-
 #'   get_dataframe_by_doi(
 #'     filedoi      = "10.70122/FK2/HXJVJU/SA3Z2V",
 #'     server       = "demo.dataverse.org"
 #'   )
 #'
-#' # Retrieve ingested file originally a Stata dta
-#' df_from_stata_ingested <-
-#'   get_dataframe_by_name(
-#'     filename   = "nlsw88.tab",
-#'     dataset    = "doi:10.70122/FK2/PPIAXE",
-#'     server     = "demo.dataverse.org"
-#'   )
+#' # 2. For files where Dataverse's ingest loses information (Stata .dta, SPSS .sav)
+#' # or cannot be ingested (R .rds), we recommend
+#' # specifying `original = TRUE` and specifying a read-in function in .f.
 #'
-#' # To use the original file version, or for non-ingested data,
-#' # please specify `original = TRUE` and specify a function in .f.
-#'
-# Rds files are not ingested so original = TRUE and .f is required.
+#' # Rds files are not ingested so original = TRUE and .f is required.
 #' if (requireNamespace("readr", quietly = TRUE)) {
 #'   df_from_rds_original <-
 #'     get_dataframe_by_name(
@@ -64,7 +63,8 @@
 #'     )
 #' }
 #'
-#' # Get Stata file as original
+#' # Stata dta files lose attributes such as value labels upon ingest so
+#' # reading the original version by a Stata reader such as `haven` is recommended.
 #' if (requireNamespace("haven", quietly = TRUE)) {
 #'   df_stata_original <-
 #'     get_dataframe_by_name(
@@ -76,14 +76,31 @@
 #'     )
 #' }
 #'
-#' # Stata file as ingested file (less information than original)
-#' df_stata_ingested <-
-#'   get_dataframe_by_name(
-#'     filename   = "nlsw88.tab",
-#'     dataset    = "doi:10.70122/FK2/PPIAXE",
-#'     server     = "demo.dataverse.org"
-#'  )
+#' # 3. RData files are read in by `base::load()` but cannot be assigned to an
+#' # object name. The following shows two possible ways to read in such files.
 #'
+#' # First, without relying on `get_dataframe_*`, write as a binary file:
+#' as_binary <- get_file_by_doi(
+#'  filedoi = "doi:10.70122/FK2/PPIAXE/5VPXKE",
+#'  server = "demo.dataverse.org")
+#'
+#' temp <- tempdir()
+#' writeBin(as_binary, path(temp, "county.RData"))
+#' load(path(temp, "county.RData"))
+#'
+#' If you are certain each RData contains only one object, one could define a custom
+#' custom function used in https://stackoverflow.com/a/34926943
+#' load_object <- function(file) {
+#'   tmp <- new.env()
+#'   load(file = file, envir = tmp)
+#'   tmp[[ls(tmp)[1]]]
+#' }
+#'
+#' as_rda <- get_dataframe_by_doi(
+#'   filedoi = "doi:10.70122/FK2/PPIAXE/5VPXKE",
+#'   server = "demo.dataverse.org",
+#'   .f = load_object,
+#'   original = TRUE)
 #' }
 #'
 #' @export

--- a/R/get_dataframe.R
+++ b/R/get_dataframe.R
@@ -20,6 +20,10 @@
 #'
 #' @inheritDotParams get_file
 #'
+#' @return A R object that is returned by the default or user-supplied function
+#'  `.f` argument. For example, if `.f = readr::read_tsv()`, the function will
+#'  return a dataframe as read in by `readr::read_tsv()`.
+#'
 #' @examples
 #' \dontrun{
 #' # Retrieve data.frame from dataverse DOI and file name

--- a/R/get_dataframe.R
+++ b/R/get_dataframe.R
@@ -96,8 +96,9 @@
 #'   tmp[[ls(tmp)[1]]]
 #' }
 #'
-#' as_rda <- get_dataframe_by_doi(
-#'   filedoi = "doi:10.70122/FK2/PPIAXE/5VPXKE",
+#' # https://demo.dataverse.org/file.xhtml?persistentId=doi:10.70122/FK2/PPIAXE/X2FC5V
+#' as_rda <- get_dataframe_by_id(
+#'   file = 1939003,
 #'   server = "demo.dataverse.org",
 #'   .f = load_object,
 #'   original = TRUE)

--- a/R/get_dataset.R
+++ b/R/get_dataset.R
@@ -1,6 +1,7 @@
 #' @rdname get_dataset
-#' @title Get dataset
-#' @description Retrieve a Dataverse dataset metadata
+#' @title Get dataset metadata
+#' @description Retrieve metadata. To actually download a data file,
+#'  see \code{\link{get_file}} or \code{\link{get_dataframe_by_name}}.
 #'
 #' @details
 #' \code{get_dataset} retrieves details about a Dataverse dataset.
@@ -14,7 +15,6 @@
 #' \dQuote{dataverse_dataset} objects, whereas \code{\link{get_dataset}} returns
 #' metadata and a data.frame of files (rather than a list of file objects).
 #'
-#' To download actual datafiles, see \code{\link{get_file}} or \code{\link{get_dataframe_by_name}}.
 #'
 #' @template ds
 #' @template version
@@ -36,6 +36,7 @@
 #' get_dataset(contents[[1]])
 #' dataset_metadata(contents[[1]])
 #'
+#' Sys.unsetenv("DATAVERSE_SERVER")
 #' }
 #' @seealso \code{\link{get_file}}
 #' @export
@@ -52,13 +53,16 @@ get_dataset <- function(
   } else {
     u <- paste0(api_url(server), "datasets/", dataset)
   }
+  browser()
   r <- httr::GET(u, httr::add_headers("X-Dataverse-key" = key), ...)
   httr::stop_for_status(r, task = httr::content(r)$message)
   parse_dataset(httr::content(r, as = "text", encoding = "UTF-8"))
 }
 
 #' @rdname get_dataset
-#' @param block A character string specifying a metadata block to retrieve. By default this is \dQuote{citation}. Other values may be available, depending on the dataset, such as \dQuote{geospatial} or \dQuote{socialscience}.
+#' @param block A character string specifying a metadata block to retrieve.
+#'  By default this is \dQuote{citation}. Other values may be available, depending
+#'  on the dataset, such as \dQuote{geospatial} or \dQuote{socialscience}.
 #'
 #' @export
 dataset_metadata <- function(

--- a/R/get_dataset.R
+++ b/R/get_dataset.R
@@ -20,7 +20,9 @@
 #' @template version
 #' @template envvars
 #' @template dots
-#' @return A list of class \dQuote{dataverse_dataset} or a list of a form dependent on the specific metadata block retrieved. \code{dataset_files} returns a list of objects of class \dQuote{dataverse_file}.
+#' @return A list of class \dQuote{dataverse_dataset} or a list of a form dependent
+#'  on the specific metadata block retrieved. \code{dataset_files} returns a list of
+#'  objects of class \dQuote{dataverse_file}.
 #' @examples
 #' \dontrun{
 #' # https://demo.dataverse.org/dataverse/dataverse-client-r

--- a/R/get_file.R
+++ b/R/get_file.R
@@ -4,8 +4,8 @@
 #'
 #' @description Download Dataverse File(s). `get_file_*`
 #' functions return a raw binary file, which cannot be readily analyzed in R.
-#' To use the objects as dataframes, see the `get_dataset_*` functions at
-#' \link{get_dataset} instead.
+#' To use the objects as dataframes, see the `get_dataframe_*` functions at
+#' \link{get_dataframe} instead.
 #'
 #' @details This function provides access to data files from a Dataverse entry.
 #' `get_file` is a general wrapper,
@@ -63,22 +63,20 @@
 #' f3 <- get_file(d3$files$id[1], server = "demo.dataverse.org")
 #'
 #' # 4. Retrieve multiple raw data in list
-#' f4_vec <- get_dataset(
+#' f4_meta <- get_dataset(
 #'   "doi:10.70122/FK2/PPIAXE",
 #'   server = "demo.dataverse.org"
-#' )$files$id
+#' )
 #'
-#' f4 <- get_file(f4_vec, server = "demo.dataverse.org")
-#' length(f4)
+#' f4 <- get_file(f4_meta$files$id, server = "demo.dataverse.org")
+#' names(f4) <- f4_meta$files$label
 #'
-#' # Write binary files
-#' # (see `get_dataframe_by_name` to load in environment)
+#' # Write binary files. To load into R environment, use get_dataframe_by_name()
 #' # The appropriate file extension needs to be assigned by the user.
-#' writeBin(f1, "nlsw88.dta")
-#' writeBin(f2, "nlsw88.dta")
 #'
-#' writeBin(f4[[1]], "nlsw88.rds") # originally a rds file
-#' writeBin(f4[[2]], "nlsw88.dta") # originally a dta file
+#' writeBin(f1, "nlsw88.dta") # .tab extension but save as dta
+#' writeBin(f4[["nlsw88_rds-export.rds"]], "nlsw88.rds") # originally a rds file
+#' writeBin(f4[["nlsw88.tab"]], "nlsw88.dta") # originally a dta file
 #' }
 #'
 #' @export

--- a/R/get_file.R
+++ b/R/get_file.R
@@ -1,11 +1,11 @@
 #' @rdname files
 #'
-#' @title Download dataverse file as a raw binary
+#' @title Download Dataverse file as a raw binary
 #'
 #' @description Download Dataverse File(s). `get_file_*`
 #' functions return a raw binary file, which cannot be readily analyzed in R.
 #' To use the objects as dataframes, see the `get_dataframe_*` functions at
-#' \link{get_dataframe} instead.
+#' `?get_dataframe` instead.
 #'
 #' @details This function provides access to data files from a Dataverse entry.
 #' `get_file` is a general wrapper,
@@ -21,7 +21,6 @@
 #' character with the file-specific DOI; or, if used without the prefix, a
 #' filename accompanied by a dataset DOI in the `dataset` argument, or an object of
 #' class \dQuote{dataverse_file} as returned by \code{\link{dataset_files}}.
-#' @param dataset @kuriwaki, can you please add a description for this parameter?
 #' @param format A character string specifying a file format for download.
 #' by default, this is \dQuote{original} (the original file format). If `NULL`,
 #' no query is added, so ingested files are returned in their ingested TSV form.

--- a/R/get_file_by_id.R
+++ b/R/get_file_by_id.R
@@ -5,6 +5,7 @@
 #' no ingested version, is set to NA. Note in `get_dataframe_*`,
 #' `original` is set to FALSE by default. Either can be changed.
 #' @param fileid A numeric ID internally used for `get_file_by_id`
+#' @param progress Whether to show a progress bar of the download. Defaults to `FALSE`.
 #'
 #' @export
 get_file_by_id <- function(
@@ -13,6 +14,7 @@ get_file_by_id <- function(
   format          = c("original", "bundle"),
   vars            = NULL,
   original        = TRUE,
+  progress        = FALSE,
   key             = Sys.getenv("DATAVERSE_KEY"),
   server          = Sys.getenv("DATAVERSE_SERVER"),
   ...
@@ -76,7 +78,14 @@ get_file_by_id <- function(
 
     # If not bundle, request single file in non-bundle format ----
     u <- paste0(api_url(server), u_part, fileid)
-    r <- httr::GET(u, httr::add_headers("X-Dataverse-key" = key), query = query, httr::progress(type = "down"), ...)
+
+    if (!progress)
+      r <- httr::GET(u, httr::add_headers("X-Dataverse-key" = key), query = query, ...)
+
+    if (progress)
+      r <- httr::GET(u, httr::add_headers("X-Dataverse-key" = key), query = query, httr::progress(type = "down"), ...)
+
+
 
     httr::stop_for_status(r, task = httr::content(r)$message)
     httr::content(r, as = "raw")

--- a/R/get_file_by_id.R
+++ b/R/get_file_by_id.R
@@ -76,7 +76,7 @@ get_file_by_id <- function(
 
     # If not bundle, request single file in non-bundle format ----
     u <- paste0(api_url(server), u_part, fileid)
-    r <- httr::GET(u, httr::add_headers("X-Dataverse-key" = key), query = query, ...)
+    r <- httr::GET(u, httr::add_headers("X-Dataverse-key" = key), query = query, httr::progress(type = "down"), ...)
 
     httr::stop_for_status(r, task = httr::content(r)$message)
     httr::content(r, as = "raw")

--- a/R/get_file_metadata.R
+++ b/R/get_file_metadata.R
@@ -6,6 +6,15 @@
 #' @return A character vector containing a DDI
 #'  metadata file.
 #'
+#' @examples
+#'
+#' \dontrun{
+#'  ddi_raw <- get_file_metadata(file = "nlsw88.tab",
+#'                               dataset = "10.70122/FK2/PPIAXE",
+#'                               server = "demo.dataverse.org")
+#'  xml2::read_xml(ddi_raw)
+#' }
+#'
 #' @export
 get_file_metadata <-
   function(file,

--- a/R/native_user.R
+++ b/R/native_user.R
@@ -26,6 +26,8 @@ create_user <- function(password, key = Sys.getenv("DATAVERSE_KEY"), server = Sy
 #'  argument to authenticate, but \code{server} must still be specified.
 #' @param user A character vector specifying a Dataverse server username.
 #' @param password A character vector specifying the password for this user.
+#' @param key A access key if needed
+#' @param ... Other arguments passed to `httr::GET`
 #'
 #' @template envvars
 #' @template dots

--- a/R/native_user.R
+++ b/R/native_user.R
@@ -26,16 +26,15 @@ create_user <- function(password, key = Sys.getenv("DATAVERSE_KEY"), server = Sy
 #'  argument to authenticate, but \code{server} must still be specified.
 #' @param user A character vector specifying a Dataverse server username.
 #' @param password A character vector specifying the password for this user.
-#' @param key A access key if needed
-#' @param ... Other arguments passed to `httr::GET`
+#' @param server The Dataverse instance. See `get_file`.
 #'
-#' @template envvars
 #' @template dots
 #'
 #' @return A list.
 #' @examples
 #' \dontrun{
-#' get_user_key("username", "password")
+#'  # Replace Username and password with personal login
+#'  get_user_key("username", "password", server = "dataverse.harvard.edu")
 #' }
 #' @export
 get_user_key <- function(user, password, server = Sys.getenv("DATAVERSE_SERVER"), ...) {

--- a/R/native_user.R
+++ b/R/native_user.R
@@ -20,11 +20,16 @@ create_user <- function(password, key = Sys.getenv("DATAVERSE_KEY"), server = Sy
 
 #' @title Get API Key
 #' @description Get a user's API key
-#' @details Use a Dataverse server's username and password login to obtain an API key for the user. This can be used if one does not yet have an API key, or desires to reset the key. This function does not require an API \code{key} argument to authenticate, but \code{server} must still be specified.
+#' @details Use a Dataverse server's username and password login to obtain an
+#'  API key for the user. This can be used if one does not yet have an API key,
+#'  or desires to reset the key. This function does not require an API \code{key}
+#'  argument to authenticate, but \code{server} must still be specified.
 #' @param user A character vector specifying a Dataverse server username.
 #' @param password A character vector specifying the password for this user.
-#' @param server A character string specifying a Dataverse server. There are multiple Dataverse installations, but the defaults is to use the Harvard Dataverse. This can be modified atomically or globally using \code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.example.com")}.
+#'
+#' @template envvars
 #' @template dots
+#'
 #' @return A list.
 #' @examples
 #' \dontrun{

--- a/R/utils.R
+++ b/R/utils.R
@@ -101,7 +101,8 @@ is_ingested <-
   function(
     fileid,
     key     = Sys.getenv("DATAVERSE_KEY"),
-    server  = Sys.getenv("DATAVERSE_SERVER")
+    server  = Sys.getenv("DATAVERSE_SERVER"),
+    ...
   ) {
     ping_metadata <- tryCatch(
       {

--- a/R/utils.R
+++ b/R/utils.R
@@ -85,18 +85,20 @@ get_fileid.dataverse_file <- function(x, ...) {
 #' Identify if file is an ingested file
 #'
 #' @param fileid A numeric fileid or file-specific DOI
+#' @param ... Arguments passed on to `get_file` (no effect here)
 #' @template envvars
 #'
-# @examples
-# # https://demo.dataverse.org/file.xhtml?persistentId=doi:10.70122/FK2/X5MUPQ/T0KKUZ
-# # nlsw88.tab
-# is_ingested(fileid = "doi:10.70122/FK2/X5MUPQ/T0KKUZ",
-#             server = "demo.dataverse.org")
-#
-# # nlsw88_rds-export.rds
-# is_ingested(fileid = "doi:10.70122/FK2/PPIAXE/SUCFNI",
-#             server = "demo.dataverse.org")
-#
+#' @examples
+#' \dontrun{
+#' # https://demo.dataverse.org/file.xhtml?persistentId=doi:10.70122/FK2/X5MUPQ/T0KKUZ
+#' # nlsw88.tab
+#' is_ingested(fileid = "doi:10.70122/FK2/X5MUPQ/T0KKUZ",
+#'             server = "demo.dataverse.org")
+#'
+#' # nlsw88_rds-export.rds
+#' is_ingested(fileid = "doi:10.70122/FK2/PPIAXE/SUCFNI",
+#'             server = "demo.dataverse.org")
+#'}
 is_ingested <-
   function(
     fileid,

--- a/README.Rmd
+++ b/README.Rmd
@@ -135,7 +135,7 @@ attr(nlsw_original$race, "labels") # original dta has value labels
 
 ### Data Archiving
 
-Dataverse provides two - basically unrelated - workflows for managing (adding, documenting, and publishing) datasets. The first is built on [SWORD v2.0](https://swordapp.org/sword-v2/). This means that to create a new dataset listing, you will have to first initialize a dataset entry with some metadata, add one or more files to the dataset, and then publish it. This looks something like the following:
+Dataverse provides two - basically unrelated - workflows for managing (adding, documenting, and publishing) datasets. The first is built on [SWORD](https://swordapp.org) (v2.0). This means that to create a new dataset listing, you will have to first initialize a dataset entry with some metadata, add one or more files to the dataset, and then publish it. This looks something like the following:
 
 ``` r
 # After setting appropriate dataverse server and environment, obtain SWORD

--- a/README.Rmd
+++ b/README.Rmd
@@ -53,12 +53,19 @@ where `examplekey12345` should be replace with your own key.
 
 #### Server
 
-Because [there are many Dataverse installations](https://dataverse.org/), all functions in the R client require specifying what server installation you are interacting with. This can be set by default with an environment variable, `DATAVERSE_SERVER`. This should be the Dataverse server, without the "https" prefix or the "/api" URL path, etc. For example, the Harvard Dataverse can be used by setting:
+Because [there are many Dataverse installations](https://dataverse.org/), all functions in the R client require specifying what server installation you are interacting with.  There are multiple ways to specify the server:
+
+1. Set the `server` argument in each function. e.g., `server = "dataverse.harvard.edu"` in the `get_dataframe_by_name()` function.
+
+2. Set the environment variable, `DATAVERSE_SERVER`, in the script to be used throughout the session.  e.g.,
 
 ``` r
 Sys.setenv("DATAVERSE_SERVER" = "dataverse.harvard.edu")
 ```
 
+3. Hard-code a default server in your own environment.  Direct your `.Renviron` file directly or open it by `usethis::edit_r_environ()`. Then enter `DATAVERSE_SERVER = "dataverse.harvard.edu"`.
+
+In all cases, values should be the Dataverse server, without the "https" prefix or the "/api" URL path, etc. 
 
 ### Data Download
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -59,10 +59,6 @@ Because [there are many Dataverse installations](https://dataverse.org/), all fu
 Sys.setenv("DATAVERSE_SERVER" = "dataverse.harvard.edu")
 ```
 
-Note: The package attempts to compensate for any malformed values, though.
-
-Currently, the package wraps the data management features of the Dataverse API. Functions for other API features - related to user management and permissions - are not currently exported in the package (but are drafted in the [source code](https://github.com/IQSS/dataverse-client-r)).
-
 
 ### Data Download
 
@@ -185,7 +181,14 @@ get_dataverse("mydataverse")
 
 Through the native API it is possible to update a dataset by modifying its metadata with `update_dataset()` or file contents using `update_dataset_file()` and then republish a new version using `publish_dataset()`.
 
-For more extensive features of updating and maintaining data, see [pyDataverse](https://pydataverse.readthedocs.io/en/latest/).
+
+### Limitations
+
+The R client is current stable for data search and download. For more extensive features of _uploading_ and maintaining data, see [pyDataverse](https://pydataverse.readthedocs.io/en/latest/).
+
+Currently, functions related to user management and permissions - are not currently exported in the package (but are drafted in the source code).
+
+
 
 
 ### Related Software

--- a/README.Rmd
+++ b/README.Rmd
@@ -19,7 +19,7 @@ Sys.setenv("DATAVERSE_SERVER" = "dataverse.harvard.edu")
 
 [![Dataverse Project logo](https://dataverse.org/files/dataverseorg/files/dataverse_project_logo-hp.png)](https://dataverse.org)
 
-The **dataverse** package provides access to [Dataverse](https://dataverse.org/) APIs (versions 4+), enabling data search, retrieval, and deposit, thus allowing R users to integrate public data sharing into the reproducible research workflow. **dataverse** is the next-generation iteration of [the **dvn** package](https://cran.r-project.org/package=dvn), which works with Dataverse 3 ("Dataverse Network") applications. **dataverse** includes numerous improvements for data search, download, and deposit.
+The **dataverse** package provides access to [Dataverse](https://dataverse.org/) APIs (versions 4+), enabling data search, retrieval, and deposit, thus allowing R users to integrate public data sharing into the reproducible research workflow. 
 
 
 ### Getting Started
@@ -42,13 +42,15 @@ library("dataverse")
 
 #### Keys
 
-Some features of the Dataverse API are public and require no authentication. This means in many cases you can search for and retrieve data without a Dataverse account for that a specific Dataverse installation. But, other features require a Dataverse account for the specific server installation of the Dataverse software, and an API key linked to that account. Instructions for obtaining an account and setting up an API key are available in the [Dataverse User Guide](https://guides.dataverse.org/en/latest/user/account.html). (Note: if your key is compromised, it can be regenerated to preserve security.) Once you have an API key, this should be stored as an environment variable called `DATAVERSE_KEY`. It can be set within R using:
+Many features of the Dataverse API are public and require no authentication. This means in many cases you can search for and retrieve data without a Dataverse account or API key -- you wil not need to worry about this. 
+
+For features that require a Dataverse account for the specific server installation of the Dataverse software, and an API key linked to that account. Instructions for obtaining an account and setting up an API key are available in the [Dataverse User Guide](https://guides.dataverse.org/en/latest/user/account.html). (Note: if your key is compromised, it can be regenerated to preserve security.) Once you have an API key, this should be stored as an environment variable called `DATAVERSE_KEY`. It can be set as a default by adding
 
 ``` r
-Sys.setenv("DATAVERSE_KEY" = "examplekey12345")
+DATAVERSE_KEY="examplekey12345"
 ```
 
-where `examplekey12345` should be replace with your own key. 
+in your .Renviron file, where `examplekey12345` should be replace with your own key.  The environment file can be opened by `usethis::edit_r_environ()`.
 
 
 #### Server
@@ -200,7 +202,9 @@ Currently, functions related to user management and permissions - are not curren
 
 ### Related Software
 
-Other dataverse clients include [pyDataverse](https://pydataverse.readthedocs.io/en/latest/) for Python and the [Java client](https://github.com/IQSS/dataverse-client-java). 
+**dataverse** is the next-generation iteration of the now removed  **dvn** package, which works with Dataverse 3 ("Dataverse Network") applications. 
+
+Dataverse clients in other programming languages include [pyDataverse](https://pydataverse.readthedocs.io/en/latest/) for Python and the [Java client](https://github.com/IQSS/dataverse-client-java). For more information, see [the Dataverse API page](https://guides.dataverse.org/en/5.5/api/client-libraries.html#r).
 
 Users interested in downloading metadata from archives other than Dataverse may be interested in Kurt Hornik's [OAIHarvester](https://cran.r-project.org/package=OAIHarvester) and Scott Chamberlain's [oai](https://cran.r-project.org/package=oai), which offer metadata download from any web repository that is compliant with the [Open Archives Initiative](http://www.openarchives.org/) standards. Additionally, [rdryad](https://cran.r-project.org/package=rdryad) uses OAIHarvester to interface with [Dryad](https://datadryad.org/stash). The [rfigshare](https://cran.r-project.org/package=rfigshare) package works in a similar spirit to **dataverse** with <https://figshare.com/>.
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -135,7 +135,7 @@ attr(nlsw_original$race, "labels") # original dta has value labels
 
 ### Data Archiving
 
-Dataverse provides two - basically unrelated - workflows for managing (adding, documenting, and publishing) datasets. The first is built on [SWORD](https://swordapp.org) (v2.0). This means that to create a new dataset listing, you will have to first initialize a dataset entry with some metadata, add one or more files to the dataset, and then publish it. This looks something like the following:
+Dataverse provides two - basically unrelated - workflows for managing (adding, documenting, and publishing) datasets. The first is built on [SWORD](https://sword.cottagelabs.com/) (v2.0). This means that to create a new dataset listing, you will have to first initialize a dataset entry with some metadata, add one or more files to the dataset, and then publish it. This looks something like the following:
 
 ``` r
 # After setting appropriate dataverse server and environment, obtain SWORD

--- a/README.md
+++ b/README.md
@@ -17,10 +17,6 @@ The **dataverse** package provides access to
 [Dataverse](https://dataverse.org/) APIs (versions 4+), enabling data
 search, retrieval, and deposit, thus allowing R users to integrate
 public data sharing into the reproducible research workflow.
-**dataverse** is the next-generation iteration of [the **dvn**
-package](https://cran.r-project.org/package=dvn), which works with
-Dataverse 3 (“Dataverse Network”) applications. **dataverse** includes
-numerous improvements for data search, download, and deposit.
 
 ### Getting Started
 
@@ -40,23 +36,27 @@ remotes::install_github("iqss/dataverse-client-r")
 
 #### Keys
 
-Some features of the Dataverse API are public and require no
+Many features of the Dataverse API are public and require no
 authentication. This means in many cases you can search for and retrieve
-data without a Dataverse account for that a specific Dataverse
-installation. But, other features require a Dataverse account for the
-specific server installation of the Dataverse software, and an API key
-linked to that account. Instructions for obtaining an account and
-setting up an API key are available in the [Dataverse User
+data without a Dataverse account or API key – you wil not need to worry
+about this.
+
+For features that require a Dataverse account for the specific server
+installation of the Dataverse software, and an API key linked to that
+account. Instructions for obtaining an account and setting up an API key
+are available in the [Dataverse User
 Guide](https://guides.dataverse.org/en/latest/user/account.html). (Note:
 if your key is compromised, it can be regenerated to preserve security.)
 Once you have an API key, this should be stored as an environment
-variable called `DATAVERSE_KEY`. It can be set within R using:
+variable called `DATAVERSE_KEY`. It can be set as a default by adding
 
 ``` r
-Sys.setenv("DATAVERSE_KEY" = "examplekey12345")
+DATAVERSE_KEY="examplekey12345"
 ```
 
-where `examplekey12345` should be replace with your own key.
+in your .Renviron file, where `examplekey12345` should be replace with
+your own key. The environment file can be opened by
+`usethis::edit_r_environ()`.
 
 #### Server
 
@@ -263,9 +263,15 @@ code).
 
 ### Related Software
 
-Other dataverse clients include
+**dataverse** is the next-generation iteration of the now removed
+**dvn** package, which works with Dataverse 3 (“Dataverse Network”)
+applications.
+
+Dataverse clients in other programming languages include
 [pyDataverse](https://pydataverse.readthedocs.io/en/latest/) for Python
 and the [Java client](https://github.com/IQSS/dataverse-client-java).
+For more information, see [the Dataverse API
+page](https://guides.dataverse.org/en/5.5/api/client-libraries.html#r).
 
 Users interested in downloading metadata from archives other than
 Dataverse may be interested in Kurt Hornik’s

--- a/README.md
+++ b/README.md
@@ -63,14 +63,25 @@ where `examplekey12345` should be replace with your own key.
 Because [there are many Dataverse
 installations](https://dataverse.org/), all functions in the R client
 require specifying what server installation you are interacting with.
-This can be set by default with an environment variable,
-`DATAVERSE_SERVER`. This should be the Dataverse server, without the
-“https” prefix or the “/api” URL path, etc. For example, the Harvard
-Dataverse can be used by setting:
+There are multiple ways to specify the server:
+
+1.  Set the `server` argument in each function. e.g.,
+    `server = "dataverse.harvard.edu"` in the `get_dataframe_by_name()`
+    function.
+
+2.  Set the environment variable, `DATAVERSE_SERVER`, in the script to
+    be used throughout the session. e.g.,
 
 ``` r
 Sys.setenv("DATAVERSE_SERVER" = "dataverse.harvard.edu")
 ```
+
+3.  Hard-code a default server in your own environment. Direct your
+    `.Renviron` file directly or open it by `usethis::edit_r_environ()`.
+    Then enter `DATAVERSE_SERVER = "dataverse.harvard.edu"`.
+
+In all cases, values should be the Dataverse server, without the “https”
+prefix or the “/api” URL path, etc.
 
 ### Data Download
 

--- a/README.md
+++ b/README.md
@@ -72,15 +72,6 @@ Dataverse can be used by setting:
 Sys.setenv("DATAVERSE_SERVER" = "dataverse.harvard.edu")
 ```
 
-Note: The package attempts to compensate for any malformed values,
-though.
-
-Currently, the package wraps the data management features of the
-Dataverse API. Functions for other API features - related to user
-management and permissions - are not currently exported in the package
-(but are drafted in the [source
-code](https://github.com/IQSS/dataverse-client-r)).
-
 ### Data Download
 
 The dataverse package provides multiple interfaces to obtain data into
@@ -249,8 +240,15 @@ its metadata with `update_dataset()` or file contents using
 `update_dataset_file()` and then republish a new version using
 `publish_dataset()`.
 
-For more extensive features of updating and maintaining data, see
+### Limitations
+
+The R client is current stable for data search and download. For more
+extensive features of *uploading* and maintaining data, see
 [pyDataverse](https://pydataverse.readthedocs.io/en/latest/).
+
+Currently, functions related to user management and permissions - are
+not currently exported in the package (but are drafted in the source
+code).
 
 ### Related Software
 

--- a/README.md
+++ b/README.md
@@ -189,10 +189,10 @@ attr(nlsw_original$race, "labels") # original dta has value labels
 
 Dataverse provides two - basically unrelated - workflows for managing
 (adding, documenting, and publishing) datasets. The first is built on
-[SWORD v2.0](https://swordapp.org/sword-v2/). This means that to create
-a new dataset listing, you will have to first initialize a dataset entry
-with some metadata, add one or more files to the dataset, and then
-publish it. This looks something like the following:
+[SWORD](https://swordapp.org) (v2.0). This means that to create a new
+dataset listing, you will have to first initialize a dataset entry with
+some metadata, add one or more files to the dataset, and then publish
+it. This looks something like the following:
 
 ``` r
 # After setting appropriate dataverse server and environment, obtain SWORD

--- a/README.md
+++ b/README.md
@@ -189,10 +189,10 @@ attr(nlsw_original$race, "labels") # original dta has value labels
 
 Dataverse provides two - basically unrelated - workflows for managing
 (adding, documenting, and publishing) datasets. The first is built on
-[SWORD](https://swordapp.org) (v2.0). This means that to create a new
-dataset listing, you will have to first initialize a dataset entry with
-some metadata, add one or more files to the dataset, and then publish
-it. This looks something like the following:
+[SWORD](https://sword.cottagelabs.com/) (v2.0). This means that to
+create a new dataset listing, you will have to first initialize a
+dataset entry with some metadata, add one or more files to the dataset,
+and then publish it. This looks something like the following:
 
 ``` r
 # After setting appropriate dataverse server and environment, obtain SWORD

--- a/inst/expected-dataverse-root.yml
+++ b/inst/expected-dataverse-root.yml
@@ -11,7 +11,7 @@ description: "<span><span><span><h3>This Dataverse is for demo purposes only.</h
   about and publish to other repositories, visit The Dataverse Project at <a href=\"https://dataverse.org\"
   title=\"The Dataverse Project\" target=\"_blank\">dataverse.org</a>."
 dataverseType: UNCATEGORIZED
-creationDate: '2015-04-16T17:46:00Z'
+creationDate: '2015-04-16T21:46:00Z'
 theme:
   id: 1
   logo: HarvardShield_RGB.png

--- a/inst/expected-dataverse.yml
+++ b/inst/expected-dataverse.yml
@@ -9,5 +9,5 @@ permissionRoot: yes
 description: Dataverse for testing [dataverse-client-r](https://github.com/IQSS/dataverse-client-r)
 dataverseType: RESEARCHERS
 ownerId: 1
-creationDate: '2020-01-02T04:18:06Z'
+creationDate: '2020-01-02T09:18:06Z'
 testing_name: dataverse-client-r

--- a/man-roxygen/envvars.R
+++ b/man-roxygen/envvars.R
@@ -2,7 +2,10 @@
 #'   is not specified, functions calling authenticated API endpoints will fail.
 #'   Keys can be specified atomically or globally using
 #'   \code{Sys.setenv("DATAVERSE_KEY" = "examplekey")}.
-#' @param server A character string specifying a Dataverse server. There are
-#'   multiple Dataverse installations, but the defaults is to use the Harvard
-#'   Dataverse (`server = "dataverse.harvard.edu"`). This can be modified atomically
-#'   or globally using \code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.example.com")}.
+#' @param server A character string specifying a Dataverse server.
+#'   Multiple Dataverse installations exist, with `"dataverse.harvard.edu"` being the
+#'   most major. The server can be defined each time within a function, or it can
+#'   be set as a default via an environment variable. To set a default, run
+#'   `Sys.setenv("DATAVERSE_SERVER" = "dataverse.harvard.edu")`
+#'   or add `DATAVERSE_SERVER = "dataverse.harvard.edu` in one's `.Renviron`
+#'   file (`usethis::edit_r_environ()`), with the appropriate domain as its value.

--- a/man/add_dataset_file.Rd
+++ b/man/add_dataset_file.Rd
@@ -39,10 +39,13 @@ is not specified, functions calling authenticated API endpoints will fail.
 Keys can be specified atomically or globally using
 \code{Sys.setenv("DATAVERSE_KEY" = "examplekey")}.}
 
-\item{server}{A character string specifying a Dataverse server. There are
-multiple Dataverse installations, but the defaults is to use the Harvard
-Dataverse (\code{server = "dataverse.harvard.edu"}). This can be modified atomically
-or globally using \code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.example.com")}.}
+\item{server}{A character string specifying a Dataverse server.
+Multiple Dataverse installations exist, with \code{"dataverse.harvard.edu"} being the
+most major. The server can be defined each time within a function, or it can
+be set as a default via an environment variable. To set a default, run
+\code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.harvard.edu")}
+or add \verb{DATAVERSE_SERVER = "dataverse.harvard.edu} in one's \code{.Renviron}
+file (\code{usethis::edit_r_environ()}), with the appropriate domain as its value.}
 
 \item{...}{Additional arguments passed to an HTTP request function, such as
 \code{\link[httr]{GET}}, \code{\link[httr]{POST}}, or

--- a/man/add_file.Rd
+++ b/man/add_file.Rd
@@ -22,10 +22,13 @@ is not specified, functions calling authenticated API endpoints will fail.
 Keys can be specified atomically or globally using
 \code{Sys.setenv("DATAVERSE_KEY" = "examplekey")}.}
 
-\item{server}{A character string specifying a Dataverse server. There are
-multiple Dataverse installations, but the defaults is to use the Harvard
-Dataverse (\code{server = "dataverse.harvard.edu"}). This can be modified atomically
-or globally using \code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.example.com")}.}
+\item{server}{A character string specifying a Dataverse server.
+Multiple Dataverse installations exist, with \code{"dataverse.harvard.edu"} being the
+most major. The server can be defined each time within a function, or it can
+be set as a default via an environment variable. To set a default, run
+\code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.harvard.edu")}
+or add \verb{DATAVERSE_SERVER = "dataverse.harvard.edu} in one's \code{.Renviron}
+file (\code{usethis::edit_r_environ()}), with the appropriate domain as its value.}
 
 \item{...}{Additional arguments passed to an HTTP request function, such as
 \code{\link[httr]{GET}}, \code{\link[httr]{POST}}, or

--- a/man/create_dataset.Rd
+++ b/man/create_dataset.Rd
@@ -31,10 +31,13 @@ is not specified, functions calling authenticated API endpoints will fail.
 Keys can be specified atomically or globally using
 \code{Sys.setenv("DATAVERSE_KEY" = "examplekey")}.}
 
-\item{server}{A character string specifying a Dataverse server. There are
-multiple Dataverse installations, but the defaults is to use the Harvard
-Dataverse (\code{server = "dataverse.harvard.edu"}). This can be modified atomically
-or globally using \code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.example.com")}.}
+\item{server}{A character string specifying a Dataverse server.
+Multiple Dataverse installations exist, with \code{"dataverse.harvard.edu"} being the
+most major. The server can be defined each time within a function, or it can
+be set as a default via an environment variable. To set a default, run
+\code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.harvard.edu")}
+or add \verb{DATAVERSE_SERVER = "dataverse.harvard.edu} in one's \code{.Renviron}
+file (\code{usethis::edit_r_environ()}), with the appropriate domain as its value.}
 
 \item{...}{Additional arguments passed to an HTTP request function, such as
 \code{\link[httr]{GET}}, \code{\link[httr]{POST}}, or

--- a/man/create_dataverse.Rd
+++ b/man/create_dataverse.Rd
@@ -19,10 +19,13 @@ is not specified, functions calling authenticated API endpoints will fail.
 Keys can be specified atomically or globally using
 \code{Sys.setenv("DATAVERSE_KEY" = "examplekey")}.}
 
-\item{server}{A character string specifying a Dataverse server. There are
-multiple Dataverse installations, but the defaults is to use the Harvard
-Dataverse (\code{server = "dataverse.harvard.edu"}). This can be modified atomically
-or globally using \code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.example.com")}.}
+\item{server}{A character string specifying a Dataverse server.
+Multiple Dataverse installations exist, with \code{"dataverse.harvard.edu"} being the
+most major. The server can be defined each time within a function, or it can
+be set as a default via an environment variable. To set a default, run
+\code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.harvard.edu")}
+or add \verb{DATAVERSE_SERVER = "dataverse.harvard.edu} in one's \code{.Renviron}
+file (\code{usethis::edit_r_environ()}), with the appropriate domain as its value.}
 
 \item{...}{Additional arguments passed to an HTTP request function, such as
 \code{\link[httr]{GET}}, \code{\link[httr]{POST}}, or

--- a/man/dataset_atom.Rd
+++ b/man/dataset_atom.Rd
@@ -27,10 +27,13 @@ is not specified, functions calling authenticated API endpoints will fail.
 Keys can be specified atomically or globally using
 \code{Sys.setenv("DATAVERSE_KEY" = "examplekey")}.}
 
-\item{server}{A character string specifying a Dataverse server. There are
-multiple Dataverse installations, but the defaults is to use the Harvard
-Dataverse (\code{server = "dataverse.harvard.edu"}). This can be modified atomically
-or globally using \code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.example.com")}.}
+\item{server}{A character string specifying a Dataverse server.
+Multiple Dataverse installations exist, with \code{"dataverse.harvard.edu"} being the
+most major. The server can be defined each time within a function, or it can
+be set as a default via an environment variable. To set a default, run
+\code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.harvard.edu")}
+or add \verb{DATAVERSE_SERVER = "dataverse.harvard.edu} in one's \code{.Renviron}
+file (\code{usethis::edit_r_environ()}), with the appropriate domain as its value.}
 
 \item{...}{Additional arguments passed to an HTTP request function, such as
 \code{\link[httr]{GET}}, \code{\link[httr]{POST}}, or

--- a/man/dataset_versions.Rd
+++ b/man/dataset_versions.Rd
@@ -21,10 +21,13 @@ is not specified, functions calling authenticated API endpoints will fail.
 Keys can be specified atomically or globally using
 \code{Sys.setenv("DATAVERSE_KEY" = "examplekey")}.}
 
-\item{server}{A character string specifying a Dataverse server. There are
-multiple Dataverse installations, but the defaults is to use the Harvard
-Dataverse (\code{server = "dataverse.harvard.edu"}). This can be modified atomically
-or globally using \code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.example.com")}.}
+\item{server}{A character string specifying a Dataverse server.
+Multiple Dataverse installations exist, with \code{"dataverse.harvard.edu"} being the
+most major. The server can be defined each time within a function, or it can
+be set as a default via an environment variable. To set a default, run
+\code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.harvard.edu")}
+or add \verb{DATAVERSE_SERVER = "dataverse.harvard.edu} in one's \code{.Renviron}
+file (\code{usethis::edit_r_environ()}), with the appropriate domain as its value.}
 
 \item{...}{Additional arguments passed to an HTTP request function, such as
 \code{\link[httr]{GET}}, \code{\link[httr]{POST}}, or

--- a/man/dataverse_metadata.Rd
+++ b/man/dataverse_metadata.Rd
@@ -19,10 +19,13 @@ is not specified, functions calling authenticated API endpoints will fail.
 Keys can be specified atomically or globally using
 \code{Sys.setenv("DATAVERSE_KEY" = "examplekey")}.}
 
-\item{server}{A character string specifying a Dataverse server. There are
-multiple Dataverse installations, but the defaults is to use the Harvard
-Dataverse (\code{server = "dataverse.harvard.edu"}). This can be modified atomically
-or globally using \code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.example.com")}.}
+\item{server}{A character string specifying a Dataverse server.
+Multiple Dataverse installations exist, with \code{"dataverse.harvard.edu"} being the
+most major. The server can be defined each time within a function, or it can
+be set as a default via an environment variable. To set a default, run
+\code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.harvard.edu")}
+or add \verb{DATAVERSE_SERVER = "dataverse.harvard.edu} in one's \code{.Renviron}
+file (\code{usethis::edit_r_environ()}), with the appropriate domain as its value.}
 
 \item{...}{Additional arguments passed to an HTTP request function, such as
 \code{\link[httr]{GET}}, \code{\link[httr]{POST}}, or

--- a/man/dataverse_search.Rd
+++ b/man/dataverse_search.Rd
@@ -47,10 +47,13 @@ is not specified, functions calling authenticated API endpoints will fail.
 Keys can be specified atomically or globally using
 \code{Sys.setenv("DATAVERSE_KEY" = "examplekey")}.}
 
-\item{server}{A character string specifying a Dataverse server. There are
-multiple Dataverse installations, but the defaults is to use the Harvard
-Dataverse (\code{server = "dataverse.harvard.edu"}). This can be modified atomically
-or globally using \code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.example.com")}.}
+\item{server}{A character string specifying a Dataverse server.
+Multiple Dataverse installations exist, with \code{"dataverse.harvard.edu"} being the
+most major. The server can be defined each time within a function, or it can
+be set as a default via an environment variable. To set a default, run
+\code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.harvard.edu")}
+or add \verb{DATAVERSE_SERVER = "dataverse.harvard.edu} in one's \code{.Renviron}
+file (\code{usethis::edit_r_environ()}), with the appropriate domain as its value.}
 
 \item{verbose}{A logical indicating whether to display information about the search query (default is \code{TRUE}).}
 

--- a/man/delete_dataset.Rd
+++ b/man/delete_dataset.Rd
@@ -21,10 +21,13 @@ is not specified, functions calling authenticated API endpoints will fail.
 Keys can be specified atomically or globally using
 \code{Sys.setenv("DATAVERSE_KEY" = "examplekey")}.}
 
-\item{server}{A character string specifying a Dataverse server. There are
-multiple Dataverse installations, but the defaults is to use the Harvard
-Dataverse (\code{server = "dataverse.harvard.edu"}). This can be modified atomically
-or globally using \code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.example.com")}.}
+\item{server}{A character string specifying a Dataverse server.
+Multiple Dataverse installations exist, with \code{"dataverse.harvard.edu"} being the
+most major. The server can be defined each time within a function, or it can
+be set as a default via an environment variable. To set a default, run
+\code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.harvard.edu")}
+or add \verb{DATAVERSE_SERVER = "dataverse.harvard.edu} in one's \code{.Renviron}
+file (\code{usethis::edit_r_environ()}), with the appropriate domain as its value.}
 
 \item{...}{Additional arguments passed to an HTTP request function, such as
 \code{\link[httr]{GET}}, \code{\link[httr]{POST}}, or

--- a/man/delete_dataverse.Rd
+++ b/man/delete_dataverse.Rd
@@ -19,10 +19,13 @@ is not specified, functions calling authenticated API endpoints will fail.
 Keys can be specified atomically or globally using
 \code{Sys.setenv("DATAVERSE_KEY" = "examplekey")}.}
 
-\item{server}{A character string specifying a Dataverse server. There are
-multiple Dataverse installations, but the defaults is to use the Harvard
-Dataverse (\code{server = "dataverse.harvard.edu"}). This can be modified atomically
-or globally using \code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.example.com")}.}
+\item{server}{A character string specifying a Dataverse server.
+Multiple Dataverse installations exist, with \code{"dataverse.harvard.edu"} being the
+most major. The server can be defined each time within a function, or it can
+be set as a default via an environment variable. To set a default, run
+\code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.harvard.edu")}
+or add \verb{DATAVERSE_SERVER = "dataverse.harvard.edu} in one's \code{.Renviron}
+file (\code{usethis::edit_r_environ()}), with the appropriate domain as its value.}
 
 \item{...}{Additional arguments passed to an HTTP request function, such as
 \code{\link[httr]{GET}}, \code{\link[httr]{POST}}, or

--- a/man/delete_file.Rd
+++ b/man/delete_file.Rd
@@ -19,10 +19,13 @@ is not specified, functions calling authenticated API endpoints will fail.
 Keys can be specified atomically or globally using
 \code{Sys.setenv("DATAVERSE_KEY" = "examplekey")}.}
 
-\item{server}{A character string specifying a Dataverse server. There are
-multiple Dataverse installations, but the defaults is to use the Harvard
-Dataverse (\code{server = "dataverse.harvard.edu"}). This can be modified atomically
-or globally using \code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.example.com")}.}
+\item{server}{A character string specifying a Dataverse server.
+Multiple Dataverse installations exist, with \code{"dataverse.harvard.edu"} being the
+most major. The server can be defined each time within a function, or it can
+be set as a default via an environment variable. To set a default, run
+\code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.harvard.edu")}
+or add \verb{DATAVERSE_SERVER = "dataverse.harvard.edu} in one's \code{.Renviron}
+file (\code{usethis::edit_r_environ()}), with the appropriate domain as its value.}
 
 \item{...}{Additional arguments passed to an HTTP request function, such as
 \code{\link[httr]{GET}}, \code{\link[httr]{POST}}, or

--- a/man/delete_sword_dataset.Rd
+++ b/man/delete_sword_dataset.Rd
@@ -19,10 +19,13 @@ is not specified, functions calling authenticated API endpoints will fail.
 Keys can be specified atomically or globally using
 \code{Sys.setenv("DATAVERSE_KEY" = "examplekey")}.}
 
-\item{server}{A character string specifying a Dataverse server. There are
-multiple Dataverse installations, but the defaults is to use the Harvard
-Dataverse (\code{server = "dataverse.harvard.edu"}). This can be modified atomically
-or globally using \code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.example.com")}.}
+\item{server}{A character string specifying a Dataverse server.
+Multiple Dataverse installations exist, with \code{"dataverse.harvard.edu"} being the
+most major. The server can be defined each time within a function, or it can
+be set as a default via an environment variable. To set a default, run
+\code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.harvard.edu")}
+or add \verb{DATAVERSE_SERVER = "dataverse.harvard.edu} in one's \code{.Renviron}
+file (\code{usethis::edit_r_environ()}), with the appropriate domain as its value.}
 
 \item{...}{Additional arguments passed to an HTTP request function, such as
 \code{\link[httr]{GET}}, \code{\link[httr]{POST}}, or

--- a/man/files.Rd
+++ b/man/files.Rd
@@ -77,10 +77,13 @@ is not specified, functions calling authenticated API endpoints will fail.
 Keys can be specified atomically or globally using
 \code{Sys.setenv("DATAVERSE_KEY" = "examplekey")}.}
 
-\item{server}{A character string specifying a Dataverse server. There are
-multiple Dataverse installations, but the defaults is to use the Harvard
-Dataverse (\code{server = "dataverse.harvard.edu"}). This can be modified atomically
-or globally using \code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.example.com")}.}
+\item{server}{A character string specifying a Dataverse server.
+Multiple Dataverse installations exist, with \code{"dataverse.harvard.edu"} being the
+most major. The server can be defined each time within a function, or it can
+be set as a default via an environment variable. To set a default, run
+\code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.harvard.edu")}
+or add \verb{DATAVERSE_SERVER = "dataverse.harvard.edu} in one's \code{.Renviron}
+file (\code{usethis::edit_r_environ()}), with the appropriate domain as its value.}
 
 \item{original}{A logical, defaulting to TRUE. If a ingested (.tab) version is
 available, download the original version instead of the ingested? If there was

--- a/man/files.Rd
+++ b/man/files.Rd
@@ -5,7 +5,7 @@
 \alias{get_file_by_name}
 \alias{get_file_by_id}
 \alias{get_file_by_doi}
-\title{Download dataverse file as a raw binary}
+\title{Download Dataverse file as a raw binary}
 \usage{
 get_file(
   file,
@@ -35,6 +35,7 @@ get_file_by_id(
   format = c("original", "bundle"),
   vars = NULL,
   original = TRUE,
+  progress = FALSE,
   key = Sys.getenv("DATAVERSE_KEY"),
   server = Sys.getenv("DATAVERSE_SERVER"),
   ...
@@ -100,6 +101,8 @@ nlsw88.tab, use the ingested version.)}
 
 \item{fileid}{A numeric ID internally used for \code{get_file_by_id}}
 
+\item{progress}{Whether to show a progress bar of the download. Defaults to \code{FALSE}.}
+
 \item{filedoi}{A DOI for a single file (not the entire dataset), of the form
 \code{"10.70122/FK2/PPIAXE/MHDB0O"} or \code{"doi:10.70122/FK2/PPIAXE/MHDB0O"}}
 }
@@ -113,7 +116,7 @@ function.  To load datasets into the R environment dataframe, see
 Download Dataverse File(s). \verb{get_file_*}
 functions return a raw binary file, which cannot be readily analyzed in R.
 To use the objects as dataframes, see the \verb{get_dataframe_*} functions at
-\link{get_dataframe} instead.
+\code{?get_dataframe} instead.
 }
 \details{
 This function provides access to data files from a Dataverse entry.

--- a/man/files.Rd
+++ b/man/files.Rd
@@ -112,8 +112,8 @@ function.  To load datasets into the R environment dataframe, see
 \description{
 Download Dataverse File(s). \verb{get_file_*}
 functions return a raw binary file, which cannot be readily analyzed in R.
-To use the objects as dataframes, see the \verb{get_dataset_*} functions at
-\link{get_dataset} instead.
+To use the objects as dataframes, see the \verb{get_dataframe_*} functions at
+\link{get_dataframe} instead.
 }
 \details{
 This function provides access to data files from a Dataverse entry.
@@ -146,22 +146,20 @@ d3 <- get_dataset("doi:10.70122/FK2/PPIAXE", server = "demo.dataverse.org")
 f3 <- get_file(d3$files$id[1], server = "demo.dataverse.org")
 
 # 4. Retrieve multiple raw data in list
-f4_vec <- get_dataset(
+f4_meta <- get_dataset(
   "doi:10.70122/FK2/PPIAXE",
   server = "demo.dataverse.org"
-)$files$id
+)
 
-f4 <- get_file(f4_vec, server = "demo.dataverse.org")
-length(f4)
+f4 <- get_file(f4_meta$files$id, server = "demo.dataverse.org")
+names(f4) <- f4_meta$files$label
 
-# Write binary files
-# (see `get_dataframe_by_name` to load in environment)
+# Write binary files. To load into R environment, use get_dataframe_by_name()
 # The appropriate file extension needs to be assigned by the user.
-writeBin(f1, "nlsw88.dta")
-writeBin(f2, "nlsw88.dta")
 
-writeBin(f4[[1]], "nlsw88.rds") # originally a rds file
-writeBin(f4[[2]], "nlsw88.dta") # originally a dta file
+writeBin(f1, "nlsw88.dta") # .tab extension but save as dta
+writeBin(f4[["nlsw88_rds-export.rds"]], "nlsw88.rds") # originally a rds file
+writeBin(f4[["nlsw88.tab"]], "nlsw88.dta") # originally a dta file
 }
 
 }

--- a/man/get_dataframe.Rd
+++ b/man/get_dataframe.Rd
@@ -55,10 +55,13 @@ extract a subset of the data.}
 is not specified, functions calling authenticated API endpoints will fail.
 Keys can be specified atomically or globally using
 \code{Sys.setenv("DATAVERSE_KEY" = "examplekey")}.}
-    \item{\code{server}}{A character string specifying a Dataverse server. There are
-multiple Dataverse installations, but the defaults is to use the Harvard
-Dataverse (\code{server = "dataverse.harvard.edu"}). This can be modified atomically
-or globally using \code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.example.com")}.}
+    \item{\code{server}}{A character string specifying a Dataverse server.
+Multiple Dataverse installations exist, with \code{"dataverse.harvard.edu"} being the
+most major. The server can be defined each time within a function, or it can
+be set as a default via an environment variable. To set a default, run
+\code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.harvard.edu")}
+or add \verb{DATAVERSE_SERVER = "dataverse.harvard.edu} in one's \code{.Renviron}
+file (\code{usethis::edit_r_environ()}), with the appropriate domain as its value.}
   }}
 
 \item{fileid}{A numeric ID internally used for \code{get_file_by_id}}

--- a/man/get_dataframe.Rd
+++ b/man/get_dataframe.Rd
@@ -154,8 +154,9 @@ load_object <- function(file) {
   tmp[[ls(tmp)[1]]]
 }
 
-as_rda <- get_dataframe_by_doi(
-  filedoi = "doi:10.70122/FK2/PPIAXE/5VPXKE",
+# https://demo.dataverse.org/file.xhtml?persistentId=doi:10.70122/FK2/PPIAXE/X2FC5V
+as_rda <- get_dataframe_by_id(
+  file = 1939003,
   server = "demo.dataverse.org",
   .f = load_object,
   original = TRUE)

--- a/man/get_dataframe.Rd
+++ b/man/get_dataframe.Rd
@@ -26,15 +26,14 @@ get_dataframe_by_doi(filedoi, .f = NULL, original = FALSE, ...)
 for example \code{"doi:10.70122/FK2/HXJVJU"}. Alternatively, an object of class
 \dQuote{dataverse_dataset} obtained by \code{dataverse_contents()}.}
 
-\item{.f}{The function to used for reading in the raw dataset. This user
+\item{.f}{The function to used for reading in the raw dataset. The user
 must choose the appropriate function: for example if the target is a .rds
-file, then \code{.f} should be \code{readRDS} or \code{readr::read_rds}.}
+file, then \code{.f} should be \code{readRDS} or \code{readr::read_rds}. It can be a custom
+function defined by the user. See examples for details.}
 
-\item{original}{A logical, defaulting to TRUE. Whether to read the ingested,
+\item{original}{A logical, defaulting to \code{TRUE}. Whether to read the ingested,
 archival version of the datafile if one exists. The archival versions are tab-delimited
-\code{.tab} files so if \code{original = FALSE}, \code{.f} is set to \code{readr::read_tsv}.
-If functions to read the original version is available, then \code{original = TRUE}
-with a specified \code{.f} is better.}
+\code{.tab} files so if \code{original = FALSE}, \code{.f} is set to \code{readr::read_tsv}.}
 
 \item{...}{
   Arguments passed on to \code{\link[=get_file]{get_file}}
@@ -73,14 +72,23 @@ A R object that is returned by the default or user-supplied function
 return a dataframe as read in by \code{readr::read_tsv()}.
 }
 \description{
+Download dataverse file as a dataframe
+}
+\details{
+Reads in the Dataverse file into the R environment with any
+user-specified function, such as \code{read.csv} or \code{readr} functions.
+
 Use \code{get_dataframe_by_name} if you know the name of the datafile and the DOI
 of the dataset. Use \code{get_dataframe_by_doi} if you know the DOI of the datafile
 itself. Use \code{get_dataframe_by_id} if you know the numeric ID of the
-datafile.
+datafile. For files that are not datasets, the more generic \code{get_file} that
+downloads the content as a binary is simpler.
 }
 \examples{
 \dontrun{
-# Retrieve data.frame from dataverse DOI and file name
+# 1. For files originally in plain-text (.csv, .tsv), we recommend
+# retreiving data.frame from dataverse DOI and file name, or the file's DOI.
+
 df_tab <-
   get_dataframe_by_name(
     filename = "roster-bulls-1996.tab",
@@ -88,24 +96,17 @@ df_tab <-
     server   = "demo.dataverse.org"
   )
 
-# Retrieve the same file from file DOI
 df_tab <-
   get_dataframe_by_doi(
     filedoi      = "10.70122/FK2/HXJVJU/SA3Z2V",
     server       = "demo.dataverse.org"
   )
 
-# Retrieve ingested file originally a Stata dta
-df_from_stata_ingested <-
-  get_dataframe_by_name(
-    filename   = "nlsw88.tab",
-    dataset    = "doi:10.70122/FK2/PPIAXE",
-    server     = "demo.dataverse.org"
-  )
+# 2. For files where Dataverse's ingest loses information (Stata .dta, SPSS .sav)
+# or cannot be ingested (R .rds), we recommend
+# specifying `original = TRUE` and specifying a read-in function in .f.
 
-# To use the original file version, or for non-ingested data,
-# please specify `original = TRUE` and specify a function in .f.
-
+# Rds files are not ingested so original = TRUE and .f is required.
 if (requireNamespace("readr", quietly = TRUE)) {
   df_from_rds_original <-
     get_dataframe_by_name(
@@ -117,7 +118,8 @@ if (requireNamespace("readr", quietly = TRUE)) {
     )
 }
 
-# Get Stata file as original
+# Stata dta files lose attributes such as value labels upon ingest so
+# reading the original version by a Stata reader such as `haven` is recommended.
 if (requireNamespace("haven", quietly = TRUE)) {
   df_stata_original <-
     get_dataframe_by_name(
@@ -129,14 +131,31 @@ if (requireNamespace("haven", quietly = TRUE)) {
     )
 }
 
-# Stata file as ingested file (less information than original)
-df_stata_ingested <-
-  get_dataframe_by_name(
-    filename   = "nlsw88.tab",
-    dataset    = "doi:10.70122/FK2/PPIAXE",
-    server     = "demo.dataverse.org"
- )
+# 3. RData files are read in by `base::load()` but cannot be assigned to an
+# object name. The following shows two possible ways to read in such files.
 
+# First, without relying on `get_dataframe_*`, write as a binary file:
+as_binary <- get_file_by_doi(
+ filedoi = "doi:10.70122/FK2/PPIAXE/5VPXKE",
+ server = "demo.dataverse.org")
+
+temp <- tempdir()
+writeBin(as_binary, path(temp, "county.RData"))
+load(path(temp, "county.RData"))
+
+If you are certain each RData contains only one object, one could define a custom
+custom function used in https://stackoverflow.com/a/34926943
+load_object <- function(file) {
+  tmp <- new.env()
+  load(file = file, envir = tmp)
+  tmp[[ls(tmp)[1]]]
+}
+
+as_rda <- get_dataframe_by_doi(
+  filedoi = "doi:10.70122/FK2/PPIAXE/5VPXKE",
+  server = "demo.dataverse.org",
+  .f = load_object,
+  original = TRUE)
 }
 
 }

--- a/man/get_dataframe.Rd
+++ b/man/get_dataframe.Rd
@@ -67,6 +67,11 @@ or globally using \code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.example.com")
 \item{filedoi}{A DOI for a single file (not the entire dataset), of the form
 \code{"10.70122/FK2/PPIAXE/MHDB0O"} or \code{"doi:10.70122/FK2/PPIAXE/MHDB0O"}}
 }
+\value{
+A R object that is returned by the default or user-supplied function
+\code{.f} argument. For example, if \code{.f = readr::read_tsv()}, the function will
+return a dataframe as read in by \code{readr::read_tsv()}.
+}
 \description{
 Use \code{get_dataframe_by_name} if you know the name of the datafile and the DOI
 of the dataset. Use \code{get_dataframe_by_doi} if you know the DOI of the datafile

--- a/man/get_dataset.Rd
+++ b/man/get_dataset.Rd
@@ -55,7 +55,9 @@ or globally using \code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.example.com")
 \item{block}{A character string specifying a metadata block to retrieve. By default this is \dQuote{citation}. Other values may be available, depending on the dataset, such as \dQuote{geospatial} or \dQuote{socialscience}.}
 }
 \value{
-A list of class \dQuote{dataverse_dataset} or a list of a form dependent on the specific metadata block retrieved. \code{dataset_files} returns a list of objects of class \dQuote{dataverse_file}.
+A list of class \dQuote{dataverse_dataset} or a list of a form dependent
+on the specific metadata block retrieved. \code{dataset_files} returns a list of
+objects of class \dQuote{dataverse_file}.
 }
 \description{
 Retrieve a Dataverse dataset metadata

--- a/man/get_dataset.Rd
+++ b/man/get_dataset.Rd
@@ -43,10 +43,13 @@ is not specified, functions calling authenticated API endpoints will fail.
 Keys can be specified atomically or globally using
 \code{Sys.setenv("DATAVERSE_KEY" = "examplekey")}.}
 
-\item{server}{A character string specifying a Dataverse server. There are
-multiple Dataverse installations, but the defaults is to use the Harvard
-Dataverse (\code{server = "dataverse.harvard.edu"}). This can be modified atomically
-or globally using \code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.example.com")}.}
+\item{server}{A character string specifying a Dataverse server.
+Multiple Dataverse installations exist, with \code{"dataverse.harvard.edu"} being the
+most major. The server can be defined each time within a function, or it can
+be set as a default via an environment variable. To set a default, run
+\code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.harvard.edu")}
+or add \verb{DATAVERSE_SERVER = "dataverse.harvard.edu} in one's \code{.Renviron}
+file (\code{usethis::edit_r_environ()}), with the appropriate domain as its value.}
 
 \item{...}{Additional arguments passed to an HTTP request function, such as
 \code{\link[httr]{GET}}, \code{\link[httr]{POST}}, or

--- a/man/get_dataset.Rd
+++ b/man/get_dataset.Rd
@@ -4,7 +4,7 @@
 \alias{get_dataset}
 \alias{dataset_metadata}
 \alias{dataset_files}
-\title{Get dataset}
+\title{Get dataset metadata}
 \usage{
 get_dataset(
   dataset,
@@ -55,7 +55,9 @@ file (\code{usethis::edit_r_environ()}), with the appropriate domain as its valu
 \code{\link[httr]{GET}}, \code{\link[httr]{POST}}, or
 \code{\link[httr]{DELETE}}.}
 
-\item{block}{A character string specifying a metadata block to retrieve. By default this is \dQuote{citation}. Other values may be available, depending on the dataset, such as \dQuote{geospatial} or \dQuote{socialscience}.}
+\item{block}{A character string specifying a metadata block to retrieve.
+By default this is \dQuote{citation}. Other values may be available, depending
+on the dataset, such as \dQuote{geospatial} or \dQuote{socialscience}.}
 }
 \value{
 A list of class \dQuote{dataverse_dataset} or a list of a form dependent
@@ -63,7 +65,8 @@ on the specific metadata block retrieved. \code{dataset_files} returns a list of
 objects of class \dQuote{dataverse_file}.
 }
 \description{
-Retrieve a Dataverse dataset metadata
+Retrieve metadata. To actually download a data file,
+see \code{\link{get_file}} or \code{\link{get_dataframe_by_name}}.
 }
 \details{
 \code{get_dataset} retrieves details about a Dataverse dataset.
@@ -76,8 +79,6 @@ you to retrieve just a specific block of metadata, such as citation information.
 \code{\link{get_dataset}}. The difference is that this returns only a list of
 \dQuote{dataverse_dataset} objects, whereas \code{\link{get_dataset}} returns
 metadata and a data.frame of files (rather than a list of file objects).
-
-To download actual datafiles, see \code{\link{get_file}} or \code{\link{get_dataframe_by_name}}.
 }
 \examples{
 \dontrun{
@@ -92,6 +93,7 @@ dataset_files(contents[[1]])
 get_dataset(contents[[1]])
 dataset_metadata(contents[[1]])
 
+Sys.unsetenv("DATAVERSE_SERVER")
 }
 }
 \seealso{

--- a/man/get_dataverse.Rd
+++ b/man/get_dataverse.Rd
@@ -28,10 +28,13 @@ is not specified, functions calling authenticated API endpoints will fail.
 Keys can be specified atomically or globally using
 \code{Sys.setenv("DATAVERSE_KEY" = "examplekey")}.}
 
-\item{server}{A character string specifying a Dataverse server. There are
-multiple Dataverse installations, but the defaults is to use the Harvard
-Dataverse (\code{server = "dataverse.harvard.edu"}). This can be modified atomically
-or globally using \code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.example.com")}.}
+\item{server}{A character string specifying a Dataverse server.
+Multiple Dataverse installations exist, with \code{"dataverse.harvard.edu"} being the
+most major. The server can be defined each time within a function, or it can
+be set as a default via an environment variable. To set a default, run
+\code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.harvard.edu")}
+or add \verb{DATAVERSE_SERVER = "dataverse.harvard.edu} in one's \code{.Renviron}
+file (\code{usethis::edit_r_environ()}), with the appropriate domain as its value.}
 
 \item{check}{A logical indicating whether to check that the value of \code{dataverse} is actually a numeric}
 

--- a/man/get_facets.Rd
+++ b/man/get_facets.Rd
@@ -19,10 +19,13 @@ is not specified, functions calling authenticated API endpoints will fail.
 Keys can be specified atomically or globally using
 \code{Sys.setenv("DATAVERSE_KEY" = "examplekey")}.}
 
-\item{server}{A character string specifying a Dataverse server. There are
-multiple Dataverse installations, but the defaults is to use the Harvard
-Dataverse (\code{server = "dataverse.harvard.edu"}). This can be modified atomically
-or globally using \code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.example.com")}.}
+\item{server}{A character string specifying a Dataverse server.
+Multiple Dataverse installations exist, with \code{"dataverse.harvard.edu"} being the
+most major. The server can be defined each time within a function, or it can
+be set as a default via an environment variable. To set a default, run
+\code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.harvard.edu")}
+or add \verb{DATAVERSE_SERVER = "dataverse.harvard.edu} in one's \code{.Renviron}
+file (\code{usethis::edit_r_environ()}), with the appropriate domain as its value.}
 
 \item{...}{Additional arguments passed to an HTTP request function, such as
 \code{\link[httr]{GET}}, \code{\link[httr]{POST}}, or

--- a/man/get_file_metadata.Rd
+++ b/man/get_file_metadata.Rd
@@ -31,10 +31,13 @@ is not specified, functions calling authenticated API endpoints will fail.
 Keys can be specified atomically or globally using
 \code{Sys.setenv("DATAVERSE_KEY" = "examplekey")}.}
 
-\item{server}{A character string specifying a Dataverse server. There are
-multiple Dataverse installations, but the defaults is to use the Harvard
-Dataverse (\code{server = "dataverse.harvard.edu"}). This can be modified atomically
-or globally using \code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.example.com")}.}
+\item{server}{A character string specifying a Dataverse server.
+Multiple Dataverse installations exist, with \code{"dataverse.harvard.edu"} being the
+most major. The server can be defined each time within a function, or it can
+be set as a default via an environment variable. To set a default, run
+\code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.harvard.edu")}
+or add \verb{DATAVERSE_SERVER = "dataverse.harvard.edu} in one's \code{.Renviron}
+file (\code{usethis::edit_r_environ()}), with the appropriate domain as its value.}
 
 \item{...}{Additional arguments passed to an HTTP request function, such as
 \code{\link[httr]{GET}}, \code{\link[httr]{POST}}, or

--- a/man/get_file_metadata.Rd
+++ b/man/get_file_metadata.Rd
@@ -47,3 +47,13 @@ metadata file.
 \description{
 Retrieve a ddi metadata file
 }
+\examples{
+
+\dontrun{
+ ddi_raw <- get_file_metadata(file = "nlsw88.tab",
+                              dataset = "10.70122/FK2/PPIAXE",
+                              server = "demo.dataverse.org")
+ xml2::read_xml(ddi_raw)
+}
+
+}

--- a/man/get_user_key.Rd
+++ b/man/get_user_key.Rd
@@ -11,11 +11,22 @@ get_user_key(user, password, server = Sys.getenv("DATAVERSE_SERVER"), ...)
 
 \item{password}{A character vector specifying the password for this user.}
 
-\item{server}{A character string specifying a Dataverse server. There are multiple Dataverse installations, but the defaults is to use the Harvard Dataverse. This can be modified atomically or globally using \code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.example.com")}.}
+\item{server}{A character string specifying a Dataverse server.
+Multiple Dataverse installations exist, with \code{"dataverse.harvard.edu"} being the
+most major. The server can be defined each time within a function, or it can
+be set as a default via an environment variable. To set a default, run
+\code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.harvard.edu")}
+or add \verb{DATAVERSE_SERVER = "dataverse.harvard.edu} in one's \code{.Renviron}
+file (\code{usethis::edit_r_environ()}), with the appropriate domain as its value.}
 
 \item{...}{Additional arguments passed to an HTTP request function, such as
 \code{\link[httr]{GET}}, \code{\link[httr]{POST}}, or
 \code{\link[httr]{DELETE}}.}
+
+\item{key}{A character string specifying a Dataverse server API key. If one
+is not specified, functions calling authenticated API endpoints will fail.
+Keys can be specified atomically or globally using
+\code{Sys.setenv("DATAVERSE_KEY" = "examplekey")}.}
 }
 \value{
 A list.
@@ -24,7 +35,10 @@ A list.
 Get a user's API key
 }
 \details{
-Use a Dataverse server's username and password login to obtain an API key for the user. This can be used if one does not yet have an API key, or desires to reset the key. This function does not require an API \code{key} argument to authenticate, but \code{server} must still be specified.
+Use a Dataverse server's username and password login to obtain an
+API key for the user. This can be used if one does not yet have an API key,
+or desires to reset the key. This function does not require an API \code{key}
+argument to authenticate, but \code{server} must still be specified.
 }
 \examples{
 \dontrun{

--- a/man/get_user_key.Rd
+++ b/man/get_user_key.Rd
@@ -11,22 +11,11 @@ get_user_key(user, password, server = Sys.getenv("DATAVERSE_SERVER"), ...)
 
 \item{password}{A character vector specifying the password for this user.}
 
-\item{server}{A character string specifying a Dataverse server.
-Multiple Dataverse installations exist, with \code{"dataverse.harvard.edu"} being the
-most major. The server can be defined each time within a function, or it can
-be set as a default via an environment variable. To set a default, run
-\code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.harvard.edu")}
-or add \verb{DATAVERSE_SERVER = "dataverse.harvard.edu} in one's \code{.Renviron}
-file (\code{usethis::edit_r_environ()}), with the appropriate domain as its value.}
+\item{server}{The Dataverse instance. See \code{get_file}.}
 
 \item{...}{Additional arguments passed to an HTTP request function, such as
 \code{\link[httr]{GET}}, \code{\link[httr]{POST}}, or
 \code{\link[httr]{DELETE}}.}
-
-\item{key}{A character string specifying a Dataverse server API key. If one
-is not specified, functions calling authenticated API endpoints will fail.
-Keys can be specified atomically or globally using
-\code{Sys.setenv("DATAVERSE_KEY" = "examplekey")}.}
 }
 \value{
 A list.
@@ -42,6 +31,7 @@ argument to authenticate, but \code{server} must still be specified.
 }
 \examples{
 \dontrun{
-get_user_key("username", "password")
+ # Replace Username and password with personal login
+ get_user_key("username", "password", server = "dataverse.harvard.edu")
 }
 }

--- a/man/initiate_sword_dataset.Rd
+++ b/man/initiate_sword_dataset.Rd
@@ -22,10 +22,13 @@ is not specified, functions calling authenticated API endpoints will fail.
 Keys can be specified atomically or globally using
 \code{Sys.setenv("DATAVERSE_KEY" = "examplekey")}.}
 
-\item{server}{A character string specifying a Dataverse server. There are
-multiple Dataverse installations, but the defaults is to use the Harvard
-Dataverse (\code{server = "dataverse.harvard.edu"}). This can be modified atomically
-or globally using \code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.example.com")}.}
+\item{server}{A character string specifying a Dataverse server.
+Multiple Dataverse installations exist, with \code{"dataverse.harvard.edu"} being the
+most major. The server can be defined each time within a function, or it can
+be set as a default via an environment variable. To set a default, run
+\code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.harvard.edu")}
+or add \verb{DATAVERSE_SERVER = "dataverse.harvard.edu} in one's \code{.Renviron}
+file (\code{usethis::edit_r_environ()}), with the appropriate domain as its value.}
 
 \item{...}{Additional arguments passed to an HTTP request function, such as
 \code{\link[httr]{GET}}, \code{\link[httr]{POST}}, or

--- a/man/is_ingested.Rd
+++ b/man/is_ingested.Rd
@@ -18,10 +18,13 @@ is not specified, functions calling authenticated API endpoints will fail.
 Keys can be specified atomically or globally using
 \code{Sys.setenv("DATAVERSE_KEY" = "examplekey")}.}
 
-\item{server}{A character string specifying a Dataverse server. There are
-multiple Dataverse installations, but the defaults is to use the Harvard
-Dataverse (\code{server = "dataverse.harvard.edu"}). This can be modified atomically
-or globally using \code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.example.com")}.}
+\item{server}{A character string specifying a Dataverse server.
+Multiple Dataverse installations exist, with \code{"dataverse.harvard.edu"} being the
+most major. The server can be defined each time within a function, or it can
+be set as a default via an environment variable. To set a default, run
+\code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.harvard.edu")}
+or add \verb{DATAVERSE_SERVER = "dataverse.harvard.edu} in one's \code{.Renviron}
+file (\code{usethis::edit_r_environ()}), with the appropriate domain as its value.}
 }
 \description{
 Identify if file is an ingested file

--- a/man/is_ingested.Rd
+++ b/man/is_ingested.Rd
@@ -7,7 +7,8 @@
 is_ingested(
   fileid,
   key = Sys.getenv("DATAVERSE_KEY"),
-  server = Sys.getenv("DATAVERSE_SERVER")
+  server = Sys.getenv("DATAVERSE_SERVER"),
+  ...
 )
 }
 \arguments{
@@ -25,7 +26,21 @@ be set as a default via an environment variable. To set a default, run
 \code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.harvard.edu")}
 or add \verb{DATAVERSE_SERVER = "dataverse.harvard.edu} in one's \code{.Renviron}
 file (\code{usethis::edit_r_environ()}), with the appropriate domain as its value.}
+
+\item{...}{Arguments passed on to \code{get_file} (no effect here)}
 }
 \description{
 Identify if file is an ingested file
+}
+\examples{
+\dontrun{
+# https://demo.dataverse.org/file.xhtml?persistentId=doi:10.70122/FK2/X5MUPQ/T0KKUZ
+# nlsw88.tab
+is_ingested(fileid = "doi:10.70122/FK2/X5MUPQ/T0KKUZ",
+            server = "demo.dataverse.org")
+
+# nlsw88_rds-export.rds
+is_ingested(fileid = "doi:10.70122/FK2/PPIAXE/SUCFNI",
+            server = "demo.dataverse.org")
+}
 }

--- a/man/list_datasets.Rd
+++ b/man/list_datasets.Rd
@@ -19,10 +19,13 @@ is not specified, functions calling authenticated API endpoints will fail.
 Keys can be specified atomically or globally using
 \code{Sys.setenv("DATAVERSE_KEY" = "examplekey")}.}
 
-\item{server}{A character string specifying a Dataverse server. There are
-multiple Dataverse installations, but the defaults is to use the Harvard
-Dataverse (\code{server = "dataverse.harvard.edu"}). This can be modified atomically
-or globally using \code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.example.com")}.}
+\item{server}{A character string specifying a Dataverse server.
+Multiple Dataverse installations exist, with \code{"dataverse.harvard.edu"} being the
+most major. The server can be defined each time within a function, or it can
+be set as a default via an environment variable. To set a default, run
+\code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.harvard.edu")}
+or add \verb{DATAVERSE_SERVER = "dataverse.harvard.edu} in one's \code{.Renviron}
+file (\code{usethis::edit_r_environ()}), with the appropriate domain as its value.}
 
 \item{...}{Additional arguments passed to an HTTP request function, such as
 \code{\link[httr]{GET}}, \code{\link[httr]{POST}}, or

--- a/man/publish_dataset.Rd
+++ b/man/publish_dataset.Rd
@@ -24,10 +24,13 @@ is not specified, functions calling authenticated API endpoints will fail.
 Keys can be specified atomically or globally using
 \code{Sys.setenv("DATAVERSE_KEY" = "examplekey")}.}
 
-\item{server}{A character string specifying a Dataverse server. There are
-multiple Dataverse installations, but the defaults is to use the Harvard
-Dataverse (\code{server = "dataverse.harvard.edu"}). This can be modified atomically
-or globally using \code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.example.com")}.}
+\item{server}{A character string specifying a Dataverse server.
+Multiple Dataverse installations exist, with \code{"dataverse.harvard.edu"} being the
+most major. The server can be defined each time within a function, or it can
+be set as a default via an environment variable. To set a default, run
+\code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.harvard.edu")}
+or add \verb{DATAVERSE_SERVER = "dataverse.harvard.edu} in one's \code{.Renviron}
+file (\code{usethis::edit_r_environ()}), with the appropriate domain as its value.}
 
 \item{...}{Additional arguments passed to an HTTP request function, such as
 \code{\link[httr]{GET}}, \code{\link[httr]{POST}}, or

--- a/man/publish_dataverse.Rd
+++ b/man/publish_dataverse.Rd
@@ -19,10 +19,13 @@ is not specified, functions calling authenticated API endpoints will fail.
 Keys can be specified atomically or globally using
 \code{Sys.setenv("DATAVERSE_KEY" = "examplekey")}.}
 
-\item{server}{A character string specifying a Dataverse server. There are
-multiple Dataverse installations, but the defaults is to use the Harvard
-Dataverse (\code{server = "dataverse.harvard.edu"}). This can be modified atomically
-or globally using \code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.example.com")}.}
+\item{server}{A character string specifying a Dataverse server.
+Multiple Dataverse installations exist, with \code{"dataverse.harvard.edu"} being the
+most major. The server can be defined each time within a function, or it can
+be set as a default via an environment variable. To set a default, run
+\code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.harvard.edu")}
+or add \verb{DATAVERSE_SERVER = "dataverse.harvard.edu} in one's \code{.Renviron}
+file (\code{usethis::edit_r_environ()}), with the appropriate domain as its value.}
 
 \item{...}{Additional arguments passed to an HTTP request function, such as
 \code{\link[httr]{GET}}, \code{\link[httr]{POST}}, or

--- a/man/publish_sword_dataset.Rd
+++ b/man/publish_sword_dataset.Rd
@@ -19,10 +19,13 @@ is not specified, functions calling authenticated API endpoints will fail.
 Keys can be specified atomically or globally using
 \code{Sys.setenv("DATAVERSE_KEY" = "examplekey")}.}
 
-\item{server}{A character string specifying a Dataverse server. There are
-multiple Dataverse installations, but the defaults is to use the Harvard
-Dataverse (\code{server = "dataverse.harvard.edu"}). This can be modified atomically
-or globally using \code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.example.com")}.}
+\item{server}{A character string specifying a Dataverse server.
+Multiple Dataverse installations exist, with \code{"dataverse.harvard.edu"} being the
+most major. The server can be defined each time within a function, or it can
+be set as a default via an environment variable. To set a default, run
+\code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.harvard.edu")}
+or add \verb{DATAVERSE_SERVER = "dataverse.harvard.edu} in one's \code{.Renviron}
+file (\code{usethis::edit_r_environ()}), with the appropriate domain as its value.}
 
 \item{...}{Additional arguments passed to an HTTP request function, such as
 \code{\link[httr]{GET}}, \code{\link[httr]{POST}}, or

--- a/man/service_document.Rd
+++ b/man/service_document.Rd
@@ -16,10 +16,13 @@ is not specified, functions calling authenticated API endpoints will fail.
 Keys can be specified atomically or globally using
 \code{Sys.setenv("DATAVERSE_KEY" = "examplekey")}.}
 
-\item{server}{A character string specifying a Dataverse server. There are
-multiple Dataverse installations, but the defaults is to use the Harvard
-Dataverse (\code{server = "dataverse.harvard.edu"}). This can be modified atomically
-or globally using \code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.example.com")}.}
+\item{server}{A character string specifying a Dataverse server.
+Multiple Dataverse installations exist, with \code{"dataverse.harvard.edu"} being the
+most major. The server can be defined each time within a function, or it can
+be set as a default via an environment variable. To set a default, run
+\code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.harvard.edu")}
+or add \verb{DATAVERSE_SERVER = "dataverse.harvard.edu} in one's \code{.Renviron}
+file (\code{usethis::edit_r_environ()}), with the appropriate domain as its value.}
 
 \item{...}{Additional arguments passed to an HTTP request function, such as
 \code{\link[httr]{GET}}, \code{\link[httr]{POST}}, or

--- a/man/set_dataverse_metadata.Rd
+++ b/man/set_dataverse_metadata.Rd
@@ -25,10 +25,13 @@ is not specified, functions calling authenticated API endpoints will fail.
 Keys can be specified atomically or globally using
 \code{Sys.setenv("DATAVERSE_KEY" = "examplekey")}.}
 
-\item{server}{A character string specifying a Dataverse server. There are
-multiple Dataverse installations, but the defaults is to use the Harvard
-Dataverse (\code{server = "dataverse.harvard.edu"}). This can be modified atomically
-or globally using \code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.example.com")}.}
+\item{server}{A character string specifying a Dataverse server.
+Multiple Dataverse installations exist, with \code{"dataverse.harvard.edu"} being the
+most major. The server can be defined each time within a function, or it can
+be set as a default via an environment variable. To set a default, run
+\code{Sys.setenv("DATAVERSE_SERVER" = "dataverse.harvard.edu")}
+or add \verb{DATAVERSE_SERVER = "dataverse.harvard.edu} in one's \code{.Renviron}
+file (\code{usethis::edit_r_environ()}), with the appropriate domain as its value.}
 
 \item{...}{Additional arguments passed to an HTTP request function, such as
 \code{\link[httr]{GET}}, \code{\link[httr]{POST}}, or

--- a/tests/testthat/tests-dataset_metadata.R
+++ b/tests/testthat/tests-dataset_metadata.R
@@ -9,9 +9,9 @@ test_that("check metadata format", {
   ds_index  <- which(sapply(contents, function(x) x$identifier) == "FK2/HXJVJU")
   actual    <- dataset_metadata(contents[[ds_index]])
 
-  expect_length(actual, 2L)
-  expect_equal(actual[[1]], "Citation Metadata")
-  expect_s3_class(actual[[2]], "data.frame")
+  expect_equal(actual[["displayName"]], "Citation Metadata")
+  expect_equal(actual[["name"]], "citation")
+  expect_s3_class(actual[["fields"]], "data.frame")
 })
 
 test_that("check versions format", {

--- a/tests/testthat/tests-dataverse_contents.R
+++ b/tests/testthat/tests-dataverse_contents.R
@@ -23,6 +23,7 @@ test_that("dataverse for 'dataverse-client-r'", {
       publisher = "Demo Dataverse",
       publicationDate = "2020-12-29",
       storageIdentifier = "file://10.70122/FK2/HXJVJU",
+      metadataLanguage = "undefined",
       type = "dataset"
     ),
     class = "dataverse_dataset"

--- a/tests/testthat/tests-get_dataframe-dataframe-basketball.R
+++ b/tests/testthat/tests-get_dataframe-dataframe-basketball.R
@@ -43,3 +43,23 @@ test_that("roster-by-id", {
 
   expect_equal(actual, expected_file)
 })
+
+test_that("load-rdata", {
+  # testthat::skip_if_offline("demo.dataverse.org")
+  testthat::skip_on_cran()
+
+  # https://stackoverflow.com/a/34926943
+  f_load_rda <- function(file) {
+    tmp <- new.env()
+    load(file = file, envir = tmp)
+    tmp[[ls(tmp)[1]]]
+  }
+
+  from_rda <- get_dataframe_by_id(
+    file = 1939003,
+    server = "demo.dataverse.org",
+    .f = f_load_rda,
+    original = TRUE)
+
+  expect_s3_class(from_rda, "tbl")
+})

--- a/tests/testthat/tests-get_dataverse.R
+++ b/tests/testthat/tests-get_dataverse.R
@@ -10,7 +10,6 @@ test_that("dataverse root", {
   expect_equal(actual$id                      , expected$id)
   expect_equal(actual$alias                   , expected$alias)
   expect_equal(actual$name                    , expected$name)
-  expect_equal(actual$description             , expected$description)
   expect_equal(actual$creationDate            , expected$creationDate) # Notice this is a string
   expect_s3_class(actual$dataverseContacts    , "data.frame")
 })


### PR DESCRIPTION
Improvements for Milestone 0.3.10

- Various documentation clean-ups and clearer recommendations
- Implement a progressbar. This currently uses the built-in progress bar at `httr::GET` and defaults to FALSE to avoid it cluttering in small downloads. Ideally, we tweak the defaults so it shows up for datafiles above a certain size. 
