### PR TITLE
Skip API token expiration check if on CRAN

### DIFF
--- a/inst/constants.yml
+++ b/inst/constants.yml
@@ -1,4 +1,4 @@
 server: "demo.dataverse.org"
-api_token: "47441bb5-061c-4a8d-8724-6a1e2fc4aa4d" # readonly
-api_token_expiration: "2021-12-30"
+api_token: "93d896da-0dd2-40f6-913e-8e8385f37b88" # readonly
+api_token_expiration: "2022-01-01"
 api_token_username: "dataverse-client-r-readonly"

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -16,13 +16,18 @@ if (!requireNamespace("yaml", quietly = TRUE)) {
     Sys.setenv("DATAVERSE_SERVER" = config$server)
     Sys.setenv("DATAVERSE_KEY"    = config$api_token)
 
-    if (as.Date(config$api_token_expiration) < Sys.Date()) {
-      stop(
-        "The API token expired on `",
-        config$api_token_expiration,
-        "`, so the tests would probably fail.  ",
-        "Please regenerate a new token and update `inst/constants.yml`"
-      )
+    # To better identify the source of problems, check if the token is expired.
+    #   This check *should* be unnecessary on CRAN, since not CRAN tests should
+    #   try to access any server.
+    if (Sys.getenv("NOT_CRAN") %in% c("", "true")) {
+      if (as.Date(config$api_token_expiration) < Sys.Date()) {
+        stop(
+          "The API token expired on `",
+          config$api_token_expiration,
+          "`, so the tests would probably fail.  ",
+          "Please regenerate a new token and update `inst/constants.yml`"
+        )
+      }
     }
     rm(config)
   }


### PR DESCRIPTION
Closes #110. Also renews token (for local and Github Actions testing).

