### PR TITLE
Fix add_dataset_file() to in 0.3.10

### DIFF
--- a/R/add_dataset_file.R
+++ b/R/add_dataset_file.R
@@ -45,7 +45,7 @@ function(file,
          ...) {
     dataset <- dataset_id(dataset, key = key, server = server, ...)
 
-    bod2 <- list()
+    bod2 <- list(forceReplace = force)
     if (!is.null(description)) {
         bod2$description <- description
     }

--- a/R/add_dataset_file.R
+++ b/R/add_dataset_file.R
@@ -1,37 +1,59 @@
 #' @rdname add_dataset_file
 #' @title Add or update a file in a dataset
-#' @description Add or update a file in a dataset
-#' @details From Dataverse v4.6.1, the \dQuote{native} API provides endpoints to add and update files without going through the SWORD workflow. To use SWORD instead, see \code{\link{add_file}}. \code{add_dataset_file} adds a new file to a specified dataset.
 #'
-#' \code{update_dataset_file} can be used to replace/update a published file. Note that it only works on published files, so unpublished drafts cannot be updated - the dataset must first either be published (\code{\link{publish_dataset}}) or deleted (\code{\link{delete_dataset}}).
+#' @description Add or update a file in a dataset. For most applications, this
+#'  is the recommended function to upload your own local datasets to an
+#'  existing Dataverse dataset. Uploading requires a Dataverse API Key in the `key`
+#'  variable.
 #'
-#' @param file A character string
+#' @details From Dataverse v4.6.1, the \dQuote{native} API provides endpoints to add and
+#'  update files without going through the SWORD workflow. To use SWORD instead,
+#'  see \code{\link{add_file}}. \code{add_dataset_file} adds a new file to a specified dataset.
+#'
+#' \code{update_dataset_file} can be used to replace/update a published file.
+#'  Note that it only works on published files, so unpublished drafts cannot be updated -
+#'  the dataset must first either be published (\code{\link{publish_dataset}}) or
+#'  deleted (\code{\link{delete_dataset}}).
+#'
+#' @param file A character string for the location path of the file to be uploaded.
+#' @param dataset A character specifying a persistent identification ID for the target
+#'  dataset to update to, for example "10.70122/FK2/HXJVJU".
 #' @template ds
-#' @param id An integer specifying a file identifier; or, if \code{doi} is specified, a character string specifying a file name within the DOI-identified dataset; or an object of class \dQuote{dataverse_file} as returned by \code{\link{dataset_files}}.
+#' @param id An integer specifying a file identifier; or, if \code{doi} is specified,
+#'  a character string specifying a file name within the DOI-identified dataset; or an
+#'  object of class \dQuote{dataverse_file} as returned by \code{\link{dataset_files}}.
 #' @param description Optionally, a character string providing a description of the file.
-#' @param force A logical indicating whether to force the update even if the file types differ. Default is \code{TRUE}.
+#' @param force A logical indicating whether to force the update even if the file
+#' types differ. Default is \code{TRUE}.
+#'
 #' @template envvars
 #' @template dots
-#' @return \code{add_dataset_file} returns the new file ID.
+#'
+#' @return \code{add_dataset_file} returns the new file ID. It also uploads the file
+#'  to the dataset.
+#'
 #' @seealso \code{\link{get_dataset}}, \code{\link{delete_dataset}}, \code{\link{publish_dataset}}
+#'
 #' @examples
 #' \dontrun{
 #' meta <- list()
 #' ds <- create_dataset("mydataverse", body = meta)
 #'
+#'
+#' # Upload RDS dataset saved to local
 #' saveRDS(mtcars, tmp <- tempfile(fileext = ".rds"))
 #' f <- add_dataset_file(tmp, dataset = ds, description = "mtcars")
 #'
-#' # publish dataset
+#' # Publish dataset
 #' publish_dataset(ds)
 #'
-#' # update file and republish
+#' # Update file and republish
 #' saveRDS(iris, tmp)
 #' update_dataset_file(tmp, dataset = ds, id = f,
 #'                     description = "Actually iris")
 #' publish_dataset(ds)
 #'
-#' # cleanup
+#' # Cleanup
 #' unlink(tmp)
 #' delete_dataset(ds)
 #' }

--- a/man/add_dataset_file.Rd
+++ b/man/add_dataset_file.Rd
@@ -26,7 +26,7 @@ update_dataset_file(
 )
 }
 \arguments{
-\item{file}{A character string}
+\item{file}{A character string for the location path of the file to be uploaded.}
 
 \item{dataset}{A character specifying a persistent identification ID for a dataset,
 for example \code{"doi:10.70122/FK2/HXJVJU"}. Alternatively, an object of class
@@ -51,39 +51,53 @@ file (\code{usethis::edit_r_environ()}), with the appropriate domain as its valu
 \code{\link[httr]{GET}}, \code{\link[httr]{POST}}, or
 \code{\link[httr]{DELETE}}.}
 
-\item{id}{An integer specifying a file identifier; or, if \code{doi} is specified, a character string specifying a file name within the DOI-identified dataset; or an object of class \dQuote{dataverse_file} as returned by \code{\link{dataset_files}}.}
+\item{id}{An integer specifying a file identifier; or, if \code{doi} is specified,
+a character string specifying a file name within the DOI-identified dataset; or an
+object of class \dQuote{dataverse_file} as returned by \code{\link{dataset_files}}.}
 
-\item{force}{A logical indicating whether to force the update even if the file types differ. Default is \code{TRUE}.}
+\item{force}{A logical indicating whether to force the update even if the file
+types differ. Default is \code{TRUE}.}
 }
 \value{
-\code{add_dataset_file} returns the new file ID.
+\code{add_dataset_file} returns the new file ID. It also uploads the file
+to the dataset.
 }
 \description{
-Add or update a file in a dataset
+Add or update a file in a dataset. For most applications, this
+is the recommended function to upload your own local datasets to an
+existing Dataverse dataset. Uploading requires a Dataverse API Key in the \code{key}
+variable.
 }
 \details{
-From Dataverse v4.6.1, the \dQuote{native} API provides endpoints to add and update files without going through the SWORD workflow. To use SWORD instead, see \code{\link{add_file}}. \code{add_dataset_file} adds a new file to a specified dataset.
+From Dataverse v4.6.1, the \dQuote{native} API provides endpoints to add and
+update files without going through the SWORD workflow. To use SWORD instead,
+see \code{\link{add_file}}. \code{add_dataset_file} adds a new file to a specified dataset.
 
-\code{update_dataset_file} can be used to replace/update a published file. Note that it only works on published files, so unpublished drafts cannot be updated - the dataset must first either be published (\code{\link{publish_dataset}}) or deleted (\code{\link{delete_dataset}}).
+\code{update_dataset_file} can be used to replace/update a published file.
+Note that it only works on published files, so unpublished drafts cannot be updated -
+the dataset must first either be published (\code{\link{publish_dataset}}) or
+deleted (\code{\link{delete_dataset}}).
 }
 \examples{
 \dontrun{
 meta <- list()
 ds <- create_dataset("mydataverse", body = meta)
 
+
+# Upload RDS dataset saved to local
 saveRDS(mtcars, tmp <- tempfile(fileext = ".rds"))
 f <- add_dataset_file(tmp, dataset = ds, description = "mtcars")
 
-# publish dataset
+# Publish dataset
 publish_dataset(ds)
 
-# update file and republish
+# Update file and republish
 saveRDS(iris, tmp)
 update_dataset_file(tmp, dataset = ds, id = f,
                     description = "Actually iris")
 publish_dataset(ds)
 
-# cleanup
+# Cleanup
 unlink(tmp)
 delete_dataset(ds)
 }


### PR DESCRIPTION
Change bod2 from list() to list(forceReplace = force) . The list() resulted in jsondata being run with '[]' which is not accepted within R anymore (unsure where the issue resulted from, could be either from httr, curl). The list(forceReplace = force) was already used at update_dataset_file(). Other option would be to use NULL instead of the list().

References https://github.com/IQSS/dataverse-client-r/issues/116#issuecomment-1084251443

(note: there were some issues with closing and renewing or changing base of pull request (automatically closed it), hope everything is good now)